### PR TITLE
 Remove .reverse() from RecentActions now that wallet-toolbox returns DESC order

### DIFF
--- a/src/lib/components/RecentActions.tsx
+++ b/src/lib/components/RecentActions.tsx
@@ -39,7 +39,6 @@ const RecentActions: FC<RecentActionsProps> = ({
       </Typography>
     {appActions?.length ? (
       [...appActions] // copy so we don't mutate state/props
-        .reverse()
         .map((action, idx) => {
           const actionToDisplay = {
             txid: action.txid,


### PR DESCRIPTION
Title: Remove .reverse() from RecentActions now that wallet-toolbox returns DESC order

  Description:
  ## Summary
  - Remove `.reverse()` call in RecentActions component

  ## Problem
  RecentActions.tsx was calling `.reverse()` to compensate for wallet-toolbox returning
  transactions in ASC order. This worked when all transactions fit on one page (<10),
  but with pagination it still showed old transactions because page 0 contained the
  oldest 10 regardless of the reverse.

  ## Solution
  Remove the `.reverse()` call. This PR depends on bsv-blockchain/wallet-toolbox/pull/101 which
  fixes wallet-toolbox to return DESC order by default.

  ## Files Changed
  - `src/lib/components/RecentActions.tsx` - lines 41-42

  ## Before/After
  | Transactions | Before | After |
  |--------------|--------|-------|
  | <10 | Worked (all on page 0, reversed) | Works |
  | >10 | Broken (page 0 = oldest 10, reversed) | Works |

  ## Dependencies

  Requires bsv-blockchain/wallet-toolbox/pull/101