### PR TITLE
Add Homebrew cask for macOS installation

### DIFF
--- a/Casks/bsv-desktop.rb
+++ b/Casks/bsv-desktop.rb
@@ -1,0 +1,31 @@
+cask "bsv-desktop" do
+  arch arm: "arm64", intel: "x64"
+
+  version "2.0.6"
+
+  on_arm do
+    sha256 "60e69efdc3c23218b08a247a80d508bcc853b77cdf4dbaf76b05bb18884803e9"
+  end
+  on_intel do
+    sha256 "666f4f294730b7f5d97b667e7791e524bcec323937654da5993ca9d3a6e34217"
+  end
+
+  url "https://github.com/bsv-blockchain/bsv-desktop/releases/download/v#{version}/BSV-Desktop-#{version}-#{arch}-mac.dmg"
+  name "BSV Desktop"
+  desc "Cross-platform desktop wallet for the BSV blockchain"
+  homepage "https://github.com/bsv-blockchain/bsv-desktop"
+
+  livecheck do
+    url :homepage
+    strategy :github_latest
+  end
+
+  app "BSV-Desktop.app"
+
+  zap trash: [
+    "~/Library/Application Support/BSV-Desktop",
+    "~/Library/Logs/BSV-Desktop",
+    "~/Library/Preferences/com.bsvblockchain.bsvdesktop.plist",
+    "~/Library/Saved Application State/com.bsvblockchain.bsvdesktop.savedState",
+  ]
+end


### PR DESCRIPTION
## Summary

- Adds `Casks/bsv-desktop.rb` — a Homebrew cask formula for BSV Desktop v2.0.6
- Supports both arm64 (Apple Silicon) and x64 (Intel) macOS architectures
- Includes `livecheck` stanza for automatic version detection

## Install instructions

After merging, users can install via the bsv-blockchain tap:

```sh
brew tap bsv-blockchain/bsv-desktop
brew install --cask bsv-desktop
```

Or without adding the tap first:

```sh
brew install --cask bsv-blockchain/bsv-desktop/bsv-desktop
```

## SHA256 verification

Both checksums were computed locally against the official v2.0.6 GitHub release assets:

| File | SHA256 |
|------|--------|
| `BSV-Desktop-2.0.6-arm64-mac.dmg` | `60e69efdc3c23218b08a247a80d508bcc853b77cdf4dbaf76b05bb18884803e9` |
| `BSV-Desktop-2.0.6-x64-mac.dmg` | `666f4f294730b7f5d97b667e7791e524bcec323937654da5993ca9d3a6e34217` |

## Notes

- `livecheck` points at the GitHub latest release strategy, so `brew livecheck bsv-desktop` will detect v2.0.7+ automatically
- The `zap` stanza covers application support data, logs, preferences, and saved state
- This repository (`bsv-blockchain/bsv-desktop`) doubles as a Homebrew tap per the `homebrew-<name>` naming convention — no separate tap repo needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)