### PR TITLE
Decouple message box URL configuration from anointing

### DIFF
--- a/src/lib/WalletContext.tsx
+++ b/src/lib/WalletContext.tsx
@@ -1201,10 +1201,8 @@ export const WalletContextProvider: React.FC<WalletContextProps> = ({
         return;
       }
 
-      if (useMessageBox && !messageBoxUrl) {
-        toast.error("Message Box URL is required when Message Box is enabled");
-        return;
-      }
+      // messageBoxUrl is optional even when useMessageBox is true;
+      // the user can supply it later and anoint from Settings once they have funds.
 
       // Trim trailing slashes from URLs
       const trimmedWabUrl = (wabUrl || '').replace(/\/+$/, '');

--- a/src/lib/components/MessageBoxConfig/index.tsx
+++ b/src/lib/components/MessageBoxConfig/index.tsx
@@ -127,9 +127,9 @@ export default function MessageBoxConfig({ showTitle = true, embedded = false }:
 
             {/* Anointment Status and Actions */}
             {!isHostAnointed && (
-              <Alert severity="info" sx={{ mt: 1 }}>
+              <Alert severity="warning" sx={{ mt: 1 }}>
                 <Typography variant="body2" sx={{ mb: 1 }}>
-                  This host is not yet anointed. Anointing broadcasts your identity to the overlay network so others can send you payments and messages.
+                  Host not yet anointed. Once you have funds, anoint this host to broadcast your identity to the overlay network so others can send you payments and messages.
                 </Typography>
                 <Button
                   variant="contained"
@@ -240,7 +240,7 @@ export default function MessageBoxConfig({ showTitle = true, embedded = false }:
             autoFocus
           />
           <Alert severity="info" sx={{ mt: 2 }}>
-            After saving, you will need to anoint the host to enable receiving payments and messages.
+            After saving, you can anoint the host from Settings whenever you are ready. Anointing requires a small on-chain transaction, so make sure you have funds first.
           </Alert>
         </DialogContent>
         <DialogActions>

--- a/src/lib/components/WalletConfig.tsx
+++ b/src/lib/components/WalletConfig.tsx
@@ -365,7 +365,7 @@ const WalletConfig: React.FC = () => {
                       </Typography>
                     </FormLabel>
                     <Typography variant="body2" gutterBottom sx={{ mt: 1, mb: 2 }}>
-                      Use a message box provider for receiving messages while offline.
+                      Use a message box provider for receiving messages while offline. You can set a URL now and anoint the host later from Settings once you have funds.
                     </Typography>
                     <RadioGroup
                       value={useMessageBox.toString()}
@@ -402,7 +402,7 @@ const WalletConfig: React.FC = () => {
                         onChange={(e) => setMessageBoxUrl(e.target.value)}
                         margin="normal"
                         size="small"
-                        required
+                        helperText="You can leave this blank and configure it later in Settings."
                       />
                     </Box>
                   )}
@@ -416,8 +416,7 @@ const WalletConfig: React.FC = () => {
                   onClick={applyWalletConfig}
                   disabled={
                     (loginType === 'wab' && (!wabInfo || !method || !wabUrl)) ||
-                    (useRemoteStorage && !storageUrl) ||
-                    (useMessageBox && !messageBoxUrl)
+                    (useRemoteStorage && !storageUrl)
                   }
                 >
                   Apply Configuration

--- a/src/lib/pages/Dashboard/Payments/index.tsx
+++ b/src/lib/pages/Dashboard/Payments/index.tsx
@@ -560,39 +560,6 @@ export default function PeerPayRoute() {
     )
   }
 
-  // If Message Box is configured but host is not anointed, show anoint prompt
-  if (!isHostAnointed) {
-    return (
-      <Container maxWidth="sm">
-        <Box sx={{ minHeight: '100vh', py: 5 }}>
-          <Typography variant="h5" sx={{ mb: 2 }}>
-            Anoint Host Required
-          </Typography>
-          <Alert severity="warning" sx={{ mb: 3 }}>
-            <Typography variant="body2" sx={{ mb: 2 }}>
-              Your Message Box URL is configured, but you need to anoint the host before you can receive payments.
-              Anointing broadcasts your identity to the overlay network so others can find and send payments to you.
-            </Typography>
-            <Typography variant="body2" sx={{ mb: 2, fontFamily: 'monospace', wordBreak: 'break-all' }}>
-              Host: {messageBoxUrl}
-            </Typography>
-            <Button
-              variant="contained"
-              onClick={anointCurrentHost}
-              disabled={anointmentLoading}
-              startIcon={anointmentLoading ? <CircularProgress size={16} /> : null}
-            >
-              {anointmentLoading ? 'Anointing...' : 'Anoint Host'}
-            </Button>
-          </Alert>
-          <Typography variant="body2" color="textSecondary">
-            You can also manage your Message Box configuration in Settings.
-          </Typography>
-        </Box>
-      </Container>
-    )
-  }
-
   return (
     <Container maxWidth="sm">
       <Box sx={{ minHeight: '100vh', py: 5 }}>
@@ -601,6 +568,12 @@ export default function PeerPayRoute() {
         </Typography>
 
         <Stack spacing={2}>
+          {!isHostAnointed && (
+            <Alert severity="info">
+              Your message box host is not yet anointed. You can send payments, but others cannot find you to send payments to you until you anoint the host in Settings.
+            </Alert>
+          )}
+
           <PaymentForm
             onSent={fetchPayments}
             wallet={wallet}


### PR DESCRIPTION
## Summary

- Users can now configure a message box URL without being required to anoint the host immediately — solving the chicken-and-egg problem where anointing requires funds, but receiving funds requires a configured message box.
- The Payments page no longer hard-blocks when a host is not anointed; it shows an informational banner instead and remains fully functional for sending.
- Anointing is now a voluntary manual action available in Settings, with clear messaging that it requires an on-chain transaction and should be done once funds are available.

## Changes

- **`Payments/index.tsx`** — removed the full-page "Anoint Host Required" gate; replaced with a non-blocking `Alert` banner when not anointed.
- **`WalletConfig.tsx`** — message box URL field is no longer `required`; the apply button is no longer disabled when `useMessageBox` is true but no URL is provided; description updated to guide users to anoint later.
- **`MessageBoxConfig/index.tsx`** — not-anointed alert severity changed from `info` to `warning`; copy updated to make clear anointing is a post-funding step; dialog hint updated accordingly.
- **`WalletContext.tsx`** — removed the `finalizeConfig` validation that rejected config when `useMessageBox && !messageBoxUrl`.