### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,5 +1,7 @@
 on: [pull_request]
 name: Install and Test
+permissions:
+  contents: read
 jobs:
   test:
     name: Install & Test


### PR DESCRIPTION
Potential fix for [https://github.com/bsv-blockchain/bsv-desktop/security/code-scanning/3](https://github.com/bsv-blockchain/bsv-desktop/security/code-scanning/3)

Add an explicit `permissions` block in `.github/workflows/push.yaml` at the workflow root level (top-level keys), so it applies to all jobs unless overridden. For this workflow, the minimal required permission is:

- `contents: read`

This preserves current functionality (`actions/checkout`, dependency install, lint, tests) while enforcing least privilege for `GITHUB_TOKEN`.

Concretely, insert the block directly after `name` (or after `on`) near the top of the file:

```yaml
permissions:
  contents: read
```

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
