### PR TITLE
feat: add Who I Am as pre-approved trust certifier

### DIFF
--- a/src/lib/WalletContext.tsx
+++ b/src/lib/WalletContext.tsx
@@ -20,13 +20,13 @@ import React, {
   useRef,
 } from 'react'
 import { useMediaQuery } from '@mui/material'
-import { DEFAULT_SETTINGS, WalletSettings } from '@bsv/wallet-toolbox-client/out/src/WalletSettingsManager'
+import { WalletSettings } from '@bsv/wallet-toolbox-client/out/src/WalletSettingsManager'
 import { WalletPermissionsManager, PrivilegedKeyManager, WalletStorageManager, WalletAuthenticationManager } from '@bsv/wallet-toolbox-client'
 import { WalletInterface, Utils } from '@bsv/sdk'
 import { PeerPayClient, AdvertisementToken } from '@bsv/message-box-client'
 import 'react-toastify/dist/ReactToastify.css'
 
-import { ADMIN_ORIGINATOR } from './config'
+import { ADMIN_ORIGINATOR, DEFAULT_SETTINGS } from './config'
 import { UserContext } from './UserContext'
 import { useWalletService, getWalletService } from './hooks/useWalletService'
 import { buildPermissionModuleRegistry } from './permissionModules/registry'

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,5 +1,28 @@
+import {
+  DEFAULT_SETTINGS as LIB_DEFAULT_SETTINGS,
+  type WalletSettings,
+} from '@bsv/wallet-toolbox-client/out/src/WalletSettingsManager'
+
 // Default configuration constants
-export const DEFAULT_CHAIN = 'main';
-export const ADMIN_ORIGINATOR = 'admin.com';
-export const DEFAULT_USE_WAB = false;
-export const MESSAGEBOX_HOST = 'https://messagebox.babbage.systems';
+export const DEFAULT_CHAIN = 'main'
+export const ADMIN_ORIGINATOR = 'admin.com'
+export const DEFAULT_USE_WAB = false
+export const MESSAGEBOX_HOST = 'https://messagebox.babbage.systems'
+
+/** App-level defaults: library defaults + additional pre-approved trust certifiers */
+export const DEFAULT_SETTINGS: WalletSettings = {
+  ...LIB_DEFAULT_SETTINGS,
+  trustSettings: {
+    ...LIB_DEFAULT_SETTINGS.trustSettings,
+    trustedCertifiers: [
+      ...LIB_DEFAULT_SETTINGS.trustSettings.trustedCertifiers,
+      {
+        name: 'Who I Am',
+        description: 'Certifies email, phone, and X account ownership',
+        iconUrl: 'https://whoiam.bsvblockchain.tech/whoiam.png',
+        identityKey: '02e7eeb3986273db6843b790a1595ed0ff1b2ae8f43ae2e7f1a0c9db4dd3fb9441',
+        trust: 5,
+      },
+    ],
+  },
+}

--- a/src/lib/services/WalletService.ts
+++ b/src/lib/services/WalletService.ts
@@ -40,14 +40,14 @@ import {
   WalletInterface,
   CachedKeyDeriver,
 } from '@bsv/sdk'
-import { WalletSettingsManager, DEFAULT_SETTINGS, WalletSettings } from '@bsv/wallet-toolbox-client/out/src/WalletSettingsManager'
+import { WalletSettingsManager, WalletSettings } from '@bsv/wallet-toolbox-client/out/src/WalletSettingsManager'
 import { toast } from 'react-toastify'
 import { EventEmittable } from './EventEmittable'
 import { PermissionQueueManager } from './PermissionQueueManager'
 import { PeerPayManager } from './PeerPayManager'
 import { StorageElectronIPC } from '../StorageElectronIPC'
 import * as secrets from './secrets'
-import { DEFAULT_CHAIN, ADMIN_ORIGINATOR, DEFAULT_USE_WAB } from '../config'
+import { DEFAULT_CHAIN, ADMIN_ORIGINATOR, DEFAULT_USE_WAB, DEFAULT_SETTINGS } from '../config'
 import type { LoginType, WABConfig } from '../WalletContext'
 import type { WalletProfile } from '../types/WalletProfile'
 
@@ -481,6 +481,9 @@ export class WalletService extends EventEmittable<WalletServiceEvents> {
       const storageManager = new WalletStorageManager(keyDeriver.identityKey, activeStorage, [])
       const signer = new WalletSigner(chain, keyDeriver as any, storageManager)
       const wallet = new Wallet(signer, services, undefined, privilegedKeyManager)
+      // Set default settings including "Who I Am" certifier before first get().
+      // config is private in the type declarations but settable at runtime.
+      ;(wallet.settingsManager as any).config = { defaultSettings: DEFAULT_SETTINGS }
 
       if (this._useRemoteStorage) {
         const client = new StorageClient(wallet, this._selectedStorageUrl)


### PR DESCRIPTION
## Summary

- Adds **Who I Am** (`https://whoiam.bsvblockchain.tech`) to the app-level default trust certifiers list, matching the approach already used in bsv-browser.
- Extends library `DEFAULT_SETTINGS` with the certifier (identity key, icon, trust score 5) and applies it via `settingsManager.config` before the first settings load so new wallets get it automatically.

## Details

Pre-approved entry:

| Field | Value |
| --- | --- |
| Name | Who I Am |
| Description | Certifies email, phone, and X account ownership |
| Icon | `https://whoiam.bsvblockchain.tech/whoiam.png` |
| Identity key | `02e7eeb3986273db6843b790a1595ed0ff1b2ae8f43ae2e7f1a0c9db4dd3fb9441` |
| Trust | 5 |

## Test plan

- [ ] Fresh wallet setup: open Trust Network page and confirm **Who I Am** appears in the default certifiers list
- [ ] Confirm Metanet Trust Services and SocialCert still appear as before
- [ ] Existing wallet with saved settings: verify settings are unchanged (defaults only apply when no settings token exists yet)
- [ ] Optional: verify Who I Am icon loads from `https://whoiam.bsvblockchain.tech/whoiam.png`