### PR TITLE
fix(ci): harden release workflow Node setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
             args: '--win'
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Delete existing draft releases for this version
         if: github.event_name == 'push'
@@ -42,10 +42,13 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y librsvg2-dev rpm
 
+      # Pin a concrete Node major (not lts/*) so setup-node does not need to
+      # resolve the LTS alias via the node-versions manifest. That lookup failed
+      # the v2.7.1 release with a GitHub Unicorn 500 HTML response.
       - name: setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: lts/*
+          node-version: '22'
 
       - name: install frontend dependencies
         run: npm install
@@ -90,7 +93,7 @@ jobs:
 
       - name: Upload macOS artifacts
         if: matrix.platform == 'macos-latest'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: macos-artifacts
           path: |
@@ -134,7 +137,7 @@ jobs:
 
       - name: Upload Linux Artifacts
         if: matrix.platform == 'ubuntu-22.04'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: linux-artifacts
           path: |
@@ -204,7 +207,7 @@ jobs:
 
       - name: Upload Windows Artifacts
         if: matrix.platform == 'windows-2022'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: windows-artifacts
           path: |
@@ -225,10 +228,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: artifacts
 


### PR DESCRIPTION
## Summary
- Fixes the failed [v2.7.1 release](https://github.com/bsv-blockchain/bsv-desktop/actions/runs/29542157614): `actions/setup-node@v4` with `node-version: lts/*` crashed while resolving the LTS alias (GitHub Unicorn HTML instead of the node-versions manifest).
- Pin `node-version: '22'` so setup-node does not need the LTS alias lookup.
- Bump `actions/checkout` `@v4` → `@v5` and `actions/setup-node` `@v4` → `@v5` (Node 24 action runtimes; silences the Node 20 deprecation warning).
- Bump upload/download artifact actions to Node 24 majors (`upload-artifact@v6`, `download-artifact@v7`).

## Test plan
- [ ] Merge to master
- [ ] Dispatch `release` workflow from master (or re-tag after merge)
- [ ] Confirm setup-node succeeds on macOS, Linux, and Windows matrix jobs
- [ ] Confirm draft release assets upload for v2.7.1