### PR TITLE
Prevent repeated app icon fallback requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "package:win": "electron-builder --win",
     "package:linux": "electron-builder --linux",
     "lint:ci": "echo 'No linting'",
-    "test": "vitest run --config vitest.config.electron.ts test/translations.test.ts",
+    "test": "vitest run --config vitest.config.electron.ts test/translations.test.ts test/appIconFallback.test.ts",
     "test:stas": "vitest run --config vitest.config.electron.ts test/stas",
     "test:tokens": "vitest run --config vitest.config.electron.ts test/tokens",
     "test:stas:db": "npm rebuild better-sqlite3 && vitest run --config vitest.config.electron.ts test/stas; npm run rebuild:electron",

--- a/src/lib/pages/Dashboard/AppCatalog/index.tsx
+++ b/src/lib/pages/Dashboard/AppCatalog/index.tsx
@@ -25,6 +25,7 @@ import { Img } from '@bsv/uhrp-react'
 
 import PageHeader from '../../../components/PageHeader'
 import { openUrl } from '../../../utils/openUrl'
+import { applyAppIconFallback, FALLBACK_APP_ICON } from '../../../utils/appIconFallback'
 
 import { AppCatalog as AppCatalogAPI } from 'metanet-apps'
 import type { PublishedApp } from 'metanet-apps/src/types'
@@ -245,7 +246,7 @@ const AppCatalog: React.FC = () => {
                       <Box sx={{ display: 'flex', alignItems: 'flex-start', mb: 1.5 }}>
                         <Box
                           component="img"
-                          src={app.metadata.icon || 'https://metanetapps.com/favicon.ico'}
+                          src={app.metadata.icon || FALLBACK_APP_ICON}
                           alt={app.metadata.name}
                           sx={{
                             width: 44,
@@ -255,7 +256,7 @@ const AppCatalog: React.FC = () => {
                             flexShrink: 0,
                           }}
                           onError={(e) => {
-                            (e.target as HTMLImageElement).src = 'https://metanetapps.com/favicon.ico'
+                            applyAppIconFallback(e.currentTarget)
                           }}
                         />
                         <Box sx={{ flex: 1, minWidth: 0 }}>

--- a/src/lib/utils/appIconFallback.ts
+++ b/src/lib/utils/appIconFallback.ts
@@ -1,0 +1,7 @@
+export const FALLBACK_APP_ICON = 'https://metanetapps.com/favicon.ico'
+
+export const applyAppIconFallback = (image: Pick<HTMLImageElement, 'src'>): void => {
+  if (image.src !== FALLBACK_APP_ICON) {
+    image.src = FALLBACK_APP_ICON
+  }
+}

--- a/test/appIconFallback.test.ts
+++ b/test/appIconFallback.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { applyAppIconFallback, FALLBACK_APP_ICON } from '../src/lib/utils/appIconFallback'
+
+describe('applyAppIconFallback', () => {
+  it('uses the fallback after an app icon fails', () => {
+    const image = { src: 'https://example.com/missing-icon.png' }
+
+    applyAppIconFallback(image)
+
+    expect(image.src).toBe(FALLBACK_APP_ICON)
+  })
+
+  it('does not reassign a failed fallback', () => {
+    let assignments = 0
+    const image = {
+      get src() {
+        return FALLBACK_APP_ICON
+      },
+      set src(_value: string) {
+        assignments += 1
+      }
+    }
+
+    applyAppIconFallback(image)
+
+    expect(assignments).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary

- centralize the App Catalog fallback icon behavior
- replace a failed app icon with the fallback only once
- add regression coverage proving a failed fallback is not assigned again

## Problem

The App Catalog image error handler unconditionally assigned `https://metanetapps.com/favicon.ico` whenever an icon failed. If that fallback image also failed to render, the error handler assigned the same URL again. Each assignment could trigger another download, creating a continuous retry loop with multiple requests per second and substantial unnecessary data use during a long-running desktop session.

## Impact

A failed app-specific icon still receives the normal fallback. If the fallback itself fails, BSV Desktop now leaves the image in its failed state instead of repeatedly downloading the same resource. Catalog and API behavior are otherwise unchanged.

## Validation

- `npm test` — 15 tests passed
- `npm run build` — renderer and Electron builds passed
- `git diff --check`