### PR TITLE
fix(release): sign Windows artifacts inside electron-builder so latest.yml matches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,10 @@ jobs:
           npm run build
           npx electron-builder --mac --publish never
 
+      - name: verify auto-update metadata (macOS)
+        if: matrix.platform == 'macos-latest'
+        run: node scripts/verify-update-metadata.mjs release
+
       - name: Upload macOS artifacts
         if: matrix.platform == 'macos-latest'
         uses: actions/upload-artifact@v6
@@ -135,6 +139,10 @@ jobs:
             gpg --detach-sign --armor SHA256SUMS
           fi
 
+      - name: verify auto-update metadata (Linux)
+        if: matrix.platform == 'ubuntu-22.04'
+        run: node scripts/verify-update-metadata.mjs release
+
       - name: Upload Linux Artifacts
         if: matrix.platform == 'ubuntu-22.04'
         uses: actions/upload-artifact@v6
@@ -174,36 +182,26 @@ jobs:
         shell: cmd
         run: smctl windows certsync
 
-      - name: build Electron app (Windows)
+      # Signing happens INSIDE electron-builder via build/win-sign.js, not as a
+      # separate step afterwards. signtool rewrites the .exe, so signing after
+      # the build left latest.yml holding the hash of the unsigned installer and
+      # every Windows auto-update failed with "sha512 checksum mismatch".
+      - name: build and sign Electron app (Windows)
         if: matrix.platform == 'windows-2022'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_IDENTITY_AUTO_DISCOVERY: false
+          WIN_SIGN_SHA1: ${{ secrets.DIGICERT_CODE_SIGNING_SHA1_HASH }}
         run: |
           npm run build
           npx electron-builder --win --publish never
 
-      - name: Sign and verify Windows executables
+      # Fails the release if any artifact no longer matches the sha512 recorded
+      # in latest.yml — the exact condition that broke Windows auto-update.
+      - name: verify auto-update metadata (Windows)
         if: matrix.platform == 'windows-2022'
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = "Stop"
-
-          $signtool = Get-ChildItem "C:\Program Files (x86)\Windows Kits\10\bin\*\x64\signtool.exe" -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty FullName
-          if (-not $signtool) { throw "signtool.exe not found." }
-
-          $targets = Get-ChildItem -Path "release" -Recurse -Include *.exe | Select-Object -ExpandProperty FullName
-          if (-not $targets) { throw "No .exe files found under release/" }
-
-          foreach ($file in $targets) {
-            Write-Host "--- Signing: $file ---"
-            & $signtool sign /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 /sha1 "${{ secrets.DIGICERT_CODE_SIGNING_SHA1_HASH }}" "$file"
-            if ($LASTEXITCODE -ne 0) { throw "Signing failed for $file" }
-
-            Write-Host "--- Verifying: $file ---"
-            & $signtool verify /pa "$file"
-            if ($LASTEXITCODE -ne 0) { throw "Verification failed for $file" }
-          }
+        shell: bash
+        run: node scripts/verify-update-metadata.mjs release
 
       - name: Upload Windows Artifacts
         if: matrix.platform == 'windows-2022'

--- a/build/win-sign.cjs
+++ b/build/win-sign.cjs
@@ -1,0 +1,81 @@
+/**
+ * electron-builder custom Windows signing hook.
+ *
+ * Why this exists: signing an .exe changes its bytes. The release workflow used
+ * to run signtool *after* `electron-builder --win` had already finished, which
+ * meant latest.yml carried the sha512 of the UNSIGNED installer while the .exe
+ * uploaded alongside it was the SIGNED one. electron-updater hashes what it
+ * downloads and compares against latest.yml, so every Windows update aborted
+ * with "sha512 checksum mismatch". macOS was unaffected because its signing and
+ * notarization happen inside electron-builder.
+ *
+ * Running signtool from here keeps signing inside the build: electron-builder
+ * calls this hook (packager.signIf) before it computes update metadata, so the
+ * hash written to latest.yml is the hash of the signed artifact.
+ *
+ * Expects the DigiCert KeyLocker certificate to already be synced into the
+ * Windows certificate store (`smctl windows certsync`) and the certificate
+ * thumbprint in WIN_SIGN_SHA1.
+ *
+ * .cjs because package.json declares "type": "module" and electron-builder
+ * loads this hook with require().
+ */
+
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const TIMESTAMP_URL = process.env.WIN_SIGN_TIMESTAMP_URL || 'http://timestamp.digicert.com';
+
+function findSigntool() {
+  if (process.env.WIN_SIGNTOOL_PATH) {
+    return process.env.WIN_SIGNTOOL_PATH;
+  }
+
+  const kitsRoot = 'C:\\Program Files (x86)\\Windows Kits\\10\\bin';
+  if (!fs.existsSync(kitsRoot)) {
+    throw new Error(`signtool.exe not found: ${kitsRoot} does not exist`);
+  }
+
+  // Prefer the highest SDK version available.
+  const candidates = fs
+    .readdirSync(kitsRoot)
+    .sort()
+    .reverse()
+    .map((dir) => path.join(kitsRoot, dir, 'x64', 'signtool.exe'))
+    .filter((candidate) => fs.existsSync(candidate));
+
+  if (candidates.length === 0) {
+    throw new Error(`signtool.exe not found under ${kitsRoot}`);
+  }
+  return candidates[0];
+}
+
+exports.default = async function sign(configuration) {
+  const file = configuration.path;
+  const sha1 = process.env.WIN_SIGN_SHA1;
+
+  if (!sha1) {
+    // Local/unsigned builds are allowed; CI must never ship unsigned artifacts.
+    if (process.env.CI) {
+      throw new Error(
+        'WIN_SIGN_SHA1 is not set. Refusing to produce unsigned Windows artifacts in CI, ' +
+          'because latest.yml would then describe an installer that no longer matches what is published.'
+      );
+    }
+    console.warn(`[win-sign] WIN_SIGN_SHA1 not set — skipping signing of ${path.basename(file)}`);
+    return;
+  }
+
+  const signtool = findSigntool();
+
+  console.log(`[win-sign] Signing: ${file}`);
+  execFileSync(
+    signtool,
+    ['sign', '/tr', TIMESTAMP_URL, '/td', 'SHA256', '/fd', 'SHA256', '/sha1', sha1, file],
+    { stdio: 'inherit' }
+  );
+
+  console.log(`[win-sign] Verifying: ${file}`);
+  execFileSync(signtool, ['verify', '/pa', file], { stdio: 'inherit' });
+};

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build:renderer": "tsc && vite build",
     "build:electron": "tsc -p tsconfig.electron.json && cp electron/storage-loader.cjs electron/updater.cjs dist-electron/",
     "icons": "bash scripts/generate-icons.sh",
+    "verify:update-metadata": "node scripts/verify-update-metadata.mjs",
     "package": "electron-builder",
     "package:mac": "electron-builder --mac",
     "package:win": "electron-builder --win",
@@ -148,7 +149,14 @@
       ],
       "icon": "build/icon.ico",
       "verifyUpdateCodeSignature": false,
-      "artifactName": "${productName}-Setup-${version}.${ext}"
+      "artifactName": "${productName}-Setup-${version}.${ext}",
+      "signtoolOptions": {
+        "sign": "build/win-sign.cjs",
+        "signingHashAlgorithms": [
+          "sha256"
+        ],
+        "rfc3161TimeStampServer": "http://timestamp.digicert.com"
+      }
     },
     "nsis": {
       "oneClick": false,

--- a/scripts/repair-published-update-metadata.mjs
+++ b/scripts/repair-published-update-metadata.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+/**
+ * Repair the auto-update metadata of an ALREADY-PUBLISHED release.
+ *
+ * Releases built before the Windows signing fix shipped a latest.yml holding
+ * the sha512 of the unsigned installer, while the signed installer was uploaded
+ * alongside it. Installed clients download the installer, hash it, and abort
+ * with "sha512 checksum mismatch". The installers themselves are fine — only
+ * the metadata is wrong — so republishing a corrected latest.yml unblocks every
+ * client in the wild without cutting a new release.
+ *
+ * Note that electron-updater only ever reads the newest release's metadata, so
+ * in practice only the latest release needs repairing.
+ *
+ * This script never guesses: it downloads the published artifacts, recomputes
+ * their hashes, and rewrites only the sha512/size fields. It is a dry run
+ * unless --apply is passed, and --apply requires the `gh` CLI.
+ *
+ * Usage:
+ *   node scripts/repair-published-update-metadata.mjs --tag v2.7.2
+ *   node scripts/repair-published-update-metadata.mjs --tag v2.7.2 --apply
+ *
+ * Options:
+ *   --tag <tag>      Release tag to inspect (required)
+ *   --repo <o/r>     Defaults to bsv-blockchain/bsv-desktop
+ *   --yml <name>     Metadata file to repair (default: latest.yml, the Windows one)
+ *   --workdir <dir>  Download location (default: .update-metadata-repair)
+ *   --apply          Upload the corrected metadata with `gh release upload --clobber`
+ */
+
+import { createHash } from 'node:crypto';
+import { createWriteStream } from 'node:fs';
+import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { createReadStream } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import path from 'node:path';
+
+function parseArgs(argv) {
+  const args = { repo: 'bsv-blockchain/bsv-desktop', yml: 'latest.yml', workdir: '.update-metadata-repair' };
+  for (let i = 0; i < argv.length; i++) {
+    const flag = argv[i];
+    if (flag === '--apply') args.apply = true;
+    else if (flag.startsWith('--')) args[flag.slice(2)] = argv[++i];
+  }
+  if (!args.tag) {
+    console.error('--tag is required, e.g. --tag v2.7.2');
+    process.exit(2);
+  }
+  return args;
+}
+
+const args = parseArgs(process.argv.slice(2));
+const baseUrl = `https://github.com/${args.repo}/releases/download/${args.tag}`;
+
+async function download(name, dest) {
+  try {
+    const existing = await stat(dest);
+    if (existing.size > 0) {
+      console.log(`  cached  ${name} (${existing.size} bytes)`);
+      return;
+    }
+  } catch {
+    // not cached yet
+  }
+
+  const url = `${baseUrl}/${name}`;
+  console.log(`  fetch   ${url}`);
+  const res = await fetch(url, { redirect: 'follow' });
+  if (!res.ok) throw new Error(`GET ${url} -> ${res.status} ${res.statusText}`);
+  await pipeline(Readable.fromWeb(res.body), createWriteStream(dest));
+}
+
+function sha512Base64(file) {
+  return new Promise((resolve, reject) => {
+    const hash = createHash('sha512');
+    createReadStream(file)
+      .on('error', reject)
+      .on('data', (chunk) => hash.update(chunk))
+      .on('end', () => resolve(hash.digest('base64')));
+  });
+}
+
+await mkdir(args.workdir, { recursive: true });
+
+console.log(`Repairing ${args.yml} for ${args.repo} ${args.tag}\n`);
+
+const ymlPath = path.join(args.workdir, args.yml);
+await download(args.yml, ymlPath);
+const original = await readFile(ymlPath, 'utf8');
+
+// Collect the artifacts referenced by the metadata, in order of appearance.
+const referenced = [...original.matchAll(/^\s*-\s*url:\s*(.+?)\s*$/gm)].map((m) => decodeURIComponent(m[1]));
+if (referenced.length === 0) {
+  console.error(`No file entries found in ${args.yml}`);
+  process.exit(1);
+}
+
+const truth = new Map();
+for (const name of referenced) {
+  const dest = path.join(args.workdir, name);
+  await download(name, dest);
+  truth.set(name, { sha512: await sha512Base64(dest), size: (await stat(dest)).size });
+}
+
+// Rewrite sha512/size in place, tracking which artifact each block belongs to.
+let currentUrl = null;
+let changes = 0;
+
+const repaired = original
+  .split(/\r?\n/)
+  .map((line) => {
+    const urlMatch = line.match(/^(\s*-\s*url:\s*)(.+?)\s*$/);
+    if (urlMatch) {
+      currentUrl = decodeURIComponent(urlMatch[2]);
+      return line;
+    }
+
+    // Top-level `path:` repeats the primary artifact; its sha512 follows.
+    const pathMatch = line.match(/^path:\s*(.+?)\s*$/);
+    if (pathMatch) {
+      currentUrl = decodeURIComponent(pathMatch[1]);
+      return line;
+    }
+
+    const fieldMatch = line.match(/^(\s*)(sha512|size):\s*(.+?)\s*$/);
+    if (!fieldMatch || !currentUrl || !truth.has(currentUrl)) return line;
+
+    const [, indent, field, oldValue] = fieldMatch;
+    const newValue = String(truth.get(currentUrl)[field]);
+    if (oldValue === newValue) return line;
+
+    changes++;
+    console.log(`\n  ${currentUrl} :: ${field}`);
+    console.log(`    was: ${oldValue}`);
+    console.log(`    now: ${newValue}`);
+    return `${indent}${field}: ${newValue}`;
+  })
+  .join('\n');
+
+console.log('');
+
+if (changes === 0) {
+  console.log(`${args.yml} for ${args.tag} is already correct — nothing to do.`);
+  process.exit(0);
+}
+
+const outPath = path.join(args.workdir, `corrected-${args.yml}`);
+await writeFile(outPath, repaired);
+console.log(`${changes} field(s) corrected. Wrote ${outPath}`);
+
+if (!args.apply) {
+  console.log('\nDry run. Re-run with --apply to publish, or upload manually:');
+  console.log(`  gh release upload ${args.tag} ${outPath} --clobber   # after renaming to ${args.yml}`);
+  process.exit(0);
+}
+
+// `gh release upload` names the asset after the file, so upload under the real name.
+const uploadPath = path.join(args.workdir, 'upload', args.yml);
+await mkdir(path.dirname(uploadPath), { recursive: true });
+await writeFile(uploadPath, repaired);
+
+console.log(`\nUploading ${args.yml} to ${args.repo} ${args.tag}...`);
+execFileSync('gh', ['release', 'upload', args.tag, uploadPath, '--clobber', '--repo', args.repo], {
+  stdio: 'inherit',
+});
+console.log('Done. Installed clients will pick up the corrected metadata on their next check.');

--- a/scripts/verify-update-metadata.mjs
+++ b/scripts/verify-update-metadata.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+/**
+ * Release guard: prove the auto-update metadata matches the artifacts we ship.
+ *
+ * electron-updater downloads the file named in latest*.yml, hashes it, and
+ * aborts the update if the hash differs from the one declared there. Any
+ * release step that rewrites an artifact after electron-builder has computed
+ * that hash silently breaks updates for every installed client — which is
+ * exactly how "sha512 checksum mismatch" shipped on Windows in v2.6.x/2.7.x.
+ *
+ * This script recomputes the hashes from the files on disk and fails the build
+ * on any mismatch, so that class of bug can never reach a release again.
+ *
+ * Usage: node scripts/verify-update-metadata.mjs [releaseDir]   (default: release)
+ */
+
+import { createHash } from 'node:crypto';
+import { createReadStream } from 'node:fs';
+import { readdir, readFile, stat } from 'node:fs/promises';
+import path from 'node:path';
+
+const releaseDir = process.argv[2] ?? 'release';
+
+/**
+ * Minimal parser for the update-metadata subset of YAML that electron-builder
+ * emits: a top-level `files:` sequence of url/sha512/size maps.
+ */
+function parseUpdateYml(text) {
+  const entries = [];
+  let current = null;
+  let inFiles = false;
+
+  for (const rawLine of text.split(/\r?\n/)) {
+    if (/^\S/.test(rawLine)) {
+      inFiles = /^files:\s*$/.test(rawLine);
+      if (current) {
+        entries.push(current);
+        current = null;
+      }
+      continue;
+    }
+    if (!inFiles) continue;
+
+    const item = rawLine.match(/^\s*-\s*url:\s*(.+?)\s*$/);
+    if (item) {
+      if (current) entries.push(current);
+      current = { url: item[1] };
+      continue;
+    }
+    const field = rawLine.match(/^\s+(sha512|size):\s*(.+?)\s*$/);
+    if (field && current) {
+      current[field[1]] = field[2];
+    }
+  }
+  if (current) entries.push(current);
+
+  return entries;
+}
+
+function sha512Base64(file) {
+  return new Promise((resolve, reject) => {
+    const hash = createHash('sha512');
+    createReadStream(file)
+      .on('error', reject)
+      .on('data', (chunk) => hash.update(chunk))
+      .on('end', () => resolve(hash.digest('base64')));
+  });
+}
+
+const ymlFiles = (await readdir(releaseDir))
+  .filter((name) => /^latest(-mac|-linux)?\.yml$/.test(name))
+  .sort();
+
+if (ymlFiles.length === 0) {
+  console.error(`No latest*.yml found in ${releaseDir}/ — nothing to verify.`);
+  process.exit(1);
+}
+
+let failures = 0;
+let checked = 0;
+
+for (const ymlName of ymlFiles) {
+  const ymlPath = path.join(releaseDir, ymlName);
+  console.log(`\n=== ${ymlName} ===`);
+
+  const entries = parseUpdateYml(await readFile(ymlPath, 'utf8'));
+  if (entries.length === 0) {
+    console.error(`  ERROR: no file entries parsed from ${ymlName}`);
+    failures++;
+    continue;
+  }
+
+  for (const entry of entries) {
+    const artifact = path.join(releaseDir, decodeURIComponent(entry.url));
+
+    let stats;
+    try {
+      stats = await stat(artifact);
+    } catch {
+      // Not every artifact listed is necessarily built on this runner.
+      console.log(`  SKIP  ${entry.url} (not present on this runner)`);
+      continue;
+    }
+
+    checked++;
+    const actual = await sha512Base64(artifact);
+    const sizeOk = entry.size == null || Number(entry.size) === stats.size;
+
+    if (actual === entry.sha512 && sizeOk) {
+      console.log(`  OK    ${entry.url}`);
+      continue;
+    }
+
+    failures++;
+    console.error(`  FAIL  ${entry.url}`);
+    console.error(`        expected sha512: ${entry.sha512}`);
+    console.error(`        actual   sha512: ${actual}`);
+    if (!sizeOk) {
+      console.error(`        expected size:   ${entry.size}`);
+      console.error(`        actual   size:   ${stats.size}`);
+    }
+  }
+}
+
+console.log('');
+if (failures > 0) {
+  console.error(
+    `Update metadata verification FAILED (${failures} mismatch(es) across ${checked} artifact(s)).\n` +
+      'An artifact was modified after electron-builder computed its hash — most likely code signing\n' +
+      'running as a separate step after the build. Sign inside electron-builder instead.'
+  );
+  process.exit(1);
+}
+
+console.log(`Update metadata verified: ${checked} artifact(s) match their declared sha512.`);


### PR DESCRIPTION
## Summary

Windows auto-update has been failing for every installed client with:

```
Update error: sha512 checksum mismatch,
expected jN3d+9f1hpw5/focPYP9n5o4IEgI3I0fO3GO/cxCnQ6MKl1YvhNi4aHzsMxCofSi2n1acGLXzK15cpDbv9Ua5A==,
got     /SQ60SJWL5CMhJiCUswufTShXOfWvg46mTFzI8Htmlgis9BsIlC97BZejyu1l7A8avqMIm30REoUOqkISWZgbQ==
```

macOS is unaffected. This PR fixes the cause, and adds a guard so it cannot recur.

## Root cause

The release workflow built, then signed:

```yaml
- name: build Electron app (Windows)
  run: npx electron-builder --win --publish never   # computes sha512 -> latest.yml

- name: Sign and verify Windows executables
  run: signtool sign ... release/*.exe              # rewrites the .exe
```

`signtool` rewrites the executable. `latest.yml` was therefore generated from the **unsigned** installer, while the **signed** installer was uploaded alongside it. `electron-updater` hashes what it downloads and compares it against `latest.yml`, so the download always completed and then failed verification.

Verified directly against the published v2.7.2 assets:

| | sha512 |
|---|---|
| declared in published `latest.yml` | `jN3d+9f1hpw5/focPYP9...` |
| actual published `BSV-Desktop-Setup-2.7.2.exe` | `/SQ60SJWL5CMhJiCUswu...` |

Those are exactly the two values in the user-facing error. The published `.exe` carries a valid `CN=BSV Association` Authenticode signature — the signature is what changed the bytes.

**Why macOS works:** mac signing and notarization run *inside* `electron-builder` (`APPLE_SIGNING_IDENTITY` is passed into the build), so `latest-mac.yml` hashes the final artifact. Windows was the only platform signing after the build. The asymmetry is visible in the metadata itself: `latest-mac.yml` entries carry `size:`, the Windows ones don't.

## Changes

**`build/win-sign.cjs`** — custom `electron-builder` signing hook running the same signtool invocation against the DigiCert KeyLocker certificate. `electron-builder` calls it from `packager.signIf()` *before* `emitArtifactBuildCompleted()` writes the update metadata, so `latest.yml` now hashes the signed installer. It also signs the uninstaller, which the post-build step could not reach (it is embedded in the installer by then). It refuses to produce unsigned artifacts when `CI` is set, and skips with a warning locally so unsigned dev builds still work.

`.cjs` rather than `.js` because `package.json` declares `"type": "module"` and `electron-builder` loads the hook with `require()` — consistent with the existing `electron/updater.cjs` and `electron/storage-loader.cjs`.

**`package.json`** — wires the hook in via `win.signtoolOptions.sign`.

**`.github/workflows/release.yml`** — removes the post-build signing step; passes the thumbprint into the build as `WIN_SIGN_SHA1`. No new secrets: it reuses `DIGICERT_CODE_SIGNING_SHA1_HASH`, and the existing `smctl windows certsync` step still supplies the certificate.

**`scripts/verify-update-metadata.mjs`** — release guard. Recomputes the sha512 of every artifact named in `latest*.yml` and fails the build on any mismatch. Runs on all three platforms before artifacts are uploaded, so any future step that rewrites an artifact after hashing breaks the release loudly instead of breaking updates silently.

**`scripts/repair-published-update-metadata.mjs`** — see below.

## Fixing clients already in the wild

Existing installs are pinned to the broken `latest.yml` on the current release and cannot update themselves out of the problem. The installers are fine — only the metadata is wrong — so republishing a corrected `latest.yml` unblocks them **without cutting a new release**:

```bash
node scripts/repair-published-update-metadata.mjs --tag v2.7.2          # dry run
node scripts/repair-published-update-metadata.mjs --tag v2.7.2 --apply  # gh release upload --clobber
```

The script downloads the published artifacts, recomputes their hashes, and rewrites only the `sha512`/`size` fields — it never guesses. Only the newest release needs repairing: `electron-updater` reads the latest release's metadata, so older releases' hashes are equally wrong but unreachable.

For v2.7.2 the corrected file is:

```yaml
version: 2.7.2
files:
  - url: BSV-Desktop-Setup-2.7.2.exe
    sha512: /SQ60SJWL5CMhJiCUswufTShXOfWvg46mTFzI8Htmlgis9BsIlC97BZejyu1l7A8avqMIm30REoUOqkISWZgbQ==
path: BSV-Desktop-Setup-2.7.2.exe
sha512: /SQ60SJWL5CMhJiCUswufTShXOfWvg46mTFzI8Htmlgis9BsIlC97BZejyu1l7A8avqMIm30REoUOqkISWZgbQ==
releaseDate: '2026-07-27T21:49:26.621Z'
```

This must be applied by someone with write access to the release; it is deliberately not automated as part of the release job.

## Testing

- Confirmed the published v2.7.2 `latest.yml` hash does not match the published `.exe`, reproducing the reported error independently of any client.
- `verify-update-metadata.mjs` **fails** on the real published v2.7.2 metadata and **passes** on corrected metadata, including multi-entry `latest-mac.yml` parsing and skipping artifacts absent from a given runner.
- `repair-published-update-metadata.mjs` dry-run against v2.7.2 corrects both the `files[].sha512` and the top-level `sha512`, and the result round-trips cleanly through the verify guard.
- `build/win-sign.cjs` loads as CJS, skips with a warning when `WIN_SIGN_SHA1` is unset locally, and hard-fails when `CI` is set.

**Not yet exercised:** a full signed `electron-builder --win` run — that requires the DigiCert secrets and only happens in CI. The first tagged release after this merge is the real test, and the new verify step will fail the build rather than ship broken metadata if anything is still off.
