### PR TITLE
fix(ssl): detect trusted localhost cert by thumbprint on Windows

### DIFF
--- a/electron/sslCert.ts
+++ b/electron/sslCert.ts
@@ -130,6 +130,19 @@ export async function generateSelfSignedCert(): Promise<CertificateKeyPair> {
 }
 
 /**
+ * SHA-1 thumbprint of a PEM certificate, lowercase hex.
+ *
+ * This is the identifier certutil prints as "Cert Hash(sha1)" and accepts as a
+ * certificate ID, so it lets us ask Windows about the exact certificate we are
+ * serving rather than about anything that happens to share a name.
+ */
+export function getCertSha1Thumbprint(certPem: string): string {
+  const cert = forge.pki.certificateFromPem(certPem);
+  const der = forge.asn1.toDer(forge.pki.certificateToAsn1(cert)).getBytes();
+  return forge.md.sha1.create().update(der).digest().toHex().toLowerCase();
+}
+
+/**
  * Checks if the certificate is trusted by the system
  */
 async function isCertTrusted(certPath: string): Promise<boolean> {
@@ -142,9 +155,23 @@ async function isCertTrusted(certPath: string): Promise<boolean> {
       await execFileAsync('security', ['verify-cert', '-c', certPath, '-p', 'ssl', '-s', 'localhost']);
       return true;
     } else if (process.platform === 'win32') {
-      // Windows: Check if cert is in trusted root store
-      const { stdout } = await execFileAsync('certutil', ['-user', '-verifystore', 'Root', 'BSV Desktop']);
-      return stdout.includes('BSV Desktop');
+      // Windows: look the certificate up in the user's trusted root store by its
+      // SHA-1 thumbprint.
+      //
+      // This used to search for "BSV Desktop", which never matched: certutil
+      // resolves a name-style certificate ID against the common name, and the
+      // CN here is "localhost" — "BSV Desktop" is only the organization. The
+      // lookup therefore failed with NTE_NOT_FOUND even when the certificate
+      // was installed and valid, execFileAsync rejected on the non-zero exit,
+      // and the app re-prompted on every single launch.
+      //
+      // The thumbprint is also exact, so a stale localhost certificate left in
+      // the store by an earlier install can no longer be mistaken for the one
+      // we are actually serving, and it is not localized — matching on
+      // certutil's human-readable output breaks on non-English Windows.
+      const thumbprint = getCertSha1Thumbprint(fs.readFileSync(certPath, 'utf8'));
+      const { stdout } = await execFileAsync('certutil', ['-user', '-verifystore', 'Root', thumbprint]);
+      return stdout.toLowerCase().includes(thumbprint);
     } else {
       // Linux: Various cert stores, hard to check reliably
       return false;

--- a/test/sslCert.test.ts
+++ b/test/sslCert.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Regression tests for the localhost certificate trust check.
+ *
+ * The Windows trust detection used to look the certificate up by "BSV Desktop",
+ * which is the organization name. certutil resolves a name-style certificate ID
+ * against the common name — "localhost" here — so the lookup always failed with
+ * NTE_NOT_FOUND, the app concluded the certificate was untrusted, and it
+ * re-prompted on every launch even though the certificate was installed.
+ *
+ * Detection now keys off the SHA-1 thumbprint, so these tests pin the
+ * thumbprint computation against Node's own X.509 parser.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { X509Certificate } from 'crypto'
+import forge from 'node-forge'
+
+vi.mock('electron', () => ({
+  app: { getPath: () => '/tmp/bsv-desktop-test' },
+  dialog: { showMessageBox: async () => ({ response: 1 }) },
+}))
+
+let sslCert: typeof import('../electron/sslCert')
+
+/** Builds a self-signed localhost cert with the same shape the app generates. */
+function makeLocalhostCert(): string {
+  const keys = forge.pki.rsa.generateKeyPair(2048)
+  const cert = forge.pki.createCertificate()
+  cert.publicKey = keys.publicKey
+  cert.serialNumber = '01'
+  cert.validity.notBefore = new Date()
+  cert.validity.notAfter = new Date()
+  cert.validity.notAfter.setFullYear(cert.validity.notBefore.getFullYear() + 1)
+
+  const attrs = [
+    { name: 'commonName', value: 'localhost' },
+    { name: 'countryName', value: 'US' },
+    { shortName: 'ST', value: 'California' },
+    { name: 'localityName', value: 'San Francisco' },
+    { name: 'organizationName', value: 'BSV Desktop' },
+    { shortName: 'OU', value: 'Development' },
+  ]
+  cert.setSubject(attrs)
+  cert.setIssuer(attrs)
+  cert.sign(keys.privateKey, forge.md.sha256.create())
+
+  return forge.pki.certificateToPem(cert)
+}
+
+describe('getCertSha1Thumbprint', () => {
+  it('matches the SHA-1 fingerprint reported by Node\'s X.509 parser', async () => {
+    sslCert = await import('../electron/sslCert')
+    const pem = makeLocalhostCert()
+
+    // Independent implementation: Node parses the DER and computes SHA-1 itself.
+    const expected = new X509Certificate(pem).fingerprint.replace(/:/g, '').toLowerCase()
+
+    expect(sslCert.getCertSha1Thumbprint(pem)).toBe(expected)
+  })
+
+  it('returns lowercase hex of the right length, as certutil prints it', async () => {
+    sslCert = await import('../electron/sslCert')
+    const thumbprint = sslCert.getCertSha1Thumbprint(makeLocalhostCert())
+
+    expect(thumbprint).toMatch(/^[0-9a-f]{40}$/)
+  })
+
+  it('distinguishes two certificates that share a common name', async () => {
+    sslCert = await import('../electron/sslCert')
+
+    // Both are CN=localhost, O=BSV Desktop — the exact collision the old
+    // name-based lookup could not tell apart. A stale certificate left in the
+    // trust store must not be mistaken for the one currently being served.
+    const first = sslCert.getCertSha1Thumbprint(makeLocalhostCert())
+    const second = sslCert.getCertSha1Thumbprint(makeLocalhostCert())
+
+    expect(first).not.toBe(second)
+  })
+})


### PR DESCRIPTION
## Summary

On Windows, BSV Desktop asks to install the localhost certificate **on every launch**, even when the certificate is already installed and valid. macOS correctly prompts only when the certificate is genuinely missing.

Installation was never broken — detection was. The certificate installs fine and stays in the store; the app just can't find it afterwards.

## Root cause

`isCertTrusted()` asked certutil for `"BSV Desktop"`:

```ts
const { stdout } = await execFileAsync('certutil', ['-user', '-verifystore', 'Root', 'BSV Desktop']);
return stdout.includes('BSV Desktop');
```

certutil resolves a name-style certificate ID against the **common name**. The CN of this certificate is `localhost` — `BSV Desktop` is only the organization (`O`). So the lookup never matched.

Reproduced on Windows 11, with the certificate confirmed present in the user's trusted root store:

```
> certutil -user -verifystore Root "BSV Desktop"
Root "Trusted Root Certification Authorities"
CertUtil: -verifystore command FAILED: 0x80090011 (-2146893807 NTE_NOT_FOUND)
CertUtil: Object was not found.
```

```
> certutil -user -verifystore Root dca4af393e3b0221fae485fbd4c9fb7197a2b3d8
...
Subject: OU=Development, O=BSV Desktop, L=San Francisco, S=California, C=US, CN=localhost
Verified Application Policies:
    1.3.6.1.5.5.7.3.1 Server Authentication
Certificate is valid
CertUtil: -verifystore command completed successfully.
```

The non-zero exit made `execFileAsync` reject, the `catch` returned `false`, and an installed certificate was treated as untrusted on every launch.

macOS is unaffected because it searches on `-c localhost`, the actual CN, and then verifies the file at `certPath` directly.

## Fix

Look the certificate up by the SHA-1 thumbprint of the file at `certPath`. Beyond fixing the match, this is better than a name lookup in three ways:

- **Exact.** A stale `localhost` certificate left in the store by an earlier install can no longer be mistaken for the one actually being served. The old name-based lookup would have reported such a certificate as trusted while the app served HTTPS with a different, untrusted one — the inverse failure, and a quieter one.
- **Not localized.** certutil's human-readable output is translated; matching against it breaks on non-English Windows. A hex thumbprint does not change.
- **Verified against a false positive.** With a deliberately unmatched ID, certutil can exit 0 and dump other certificates in the store. The thumbprint substring check is therefore load-bearing — exit code alone is not sufficient. A realistic near-miss (one hex digit flipped) correctly returns `NTE_NOT_FOUND`.

## Testing

- Confirmed on Windows 11 that the certificate was already installed and valid in the user Root store while the old lookup reported not-found — reproducing the every-launch prompt.
- Confirmed the thumbprint lookup resolves the same certificate and reports it valid.
- Confirmed a near-miss thumbprint still fails, and that an unmatched ID that exits 0 does not produce a false positive.
- `test/sslCert.test.ts` pins the thumbprint computation against Node's own X.509 parser (`crypto.X509Certificate.fingerprint`) and covers the CN-collision case the old lookup could not distinguish. 3 tests, passing.
- `tsc -p tsconfig.electron.json --noEmit` clean; existing `test/translations.test.ts` still passes.

## Note

No change to the install path, which was working. Certificates already installed by previous versions will simply start being detected — no reinstall or user action needed.

One thing deliberately left alone: expired or superseded `localhost` certificates from earlier installs stay in the trusted root store. Removing them is a destructive operation on the user's certificate store and belongs in its own change if wanted.
