### PR TITLE
fix(ssl): show cert trust prompt after the main window, parented to it

### DIFF
--- a/electron/httpServer.ts
+++ b/electron/httpServer.ts
@@ -268,9 +268,6 @@ export async function startHttpServer(mainWindow: BrowserWindow): Promise<() => 
   // Generate self-signed certificate
   const { cert, key, certPath } = await generateSelfSignedCert();
 
-  // Prompt user to trust certificate if needed
-  await ensureCertTrusted(certPath);
-
   // Start HTTPS server (2121) + HTTP fallback (3321)
   const server: Server = await new Promise((resolve, reject) => {
     const srv = https.createServer({ cert, key }, app);
@@ -290,6 +287,16 @@ export async function startHttpServer(mainWindow: BrowserWindow): Promise<() => 
       }
       reject(error);
     });
+  });
+
+  // Prompt the user to trust the certificate, once the main window is on screen.
+  //
+  // Deliberately not awaited: the servers are already listening, and startup
+  // must not block on a dialog the user may leave sitting there. Trusting the
+  // certificate affects whether clients accept the HTTPS endpoint, not whether
+  // it comes up.
+  void ensureCertTrusted(certPath, mainWindow).catch((error) => {
+    console.error('Certificate trust check failed:', error);
   });
 
   // Return cleanup function

--- a/electron/sslCert.ts
+++ b/electron/sslCert.ts
@@ -1,4 +1,4 @@
-import { app, dialog } from 'electron';
+import { app, dialog, BrowserWindow } from 'electron';
 import path from 'path';
 import fs from 'fs';
 import os from 'os';
@@ -181,11 +181,72 @@ async function isCertTrusted(certPath: string): Promise<boolean> {
   }
 }
 
+/** How long to wait for the main window before prompting anyway. */
+const WINDOW_VISIBLE_TIMEOUT_MS = 15_000;
+
+/**
+ * Resolves once the main window is actually on screen.
+ *
+ * The trust prompt used to appear before the app window did: the window is
+ * created with `show: false` and only shown on 'ready-to-show', which waits for
+ * the renderer's first paint, while the certificate work starts immediately
+ * after createWindow(). On a cold start the dialog reliably won the race, so
+ * the first thing a new user saw was an unexplained certificate prompt floating
+ * over the desktop with no application behind it — and most people dismissed
+ * it, leaving the HTTPS substrate untrusted.
+ *
+ * Falls through after a timeout so a window that never paints can never leave
+ * the user unable to trust the certificate at all.
+ */
+async function waitForWindowVisible(window: BrowserWindow): Promise<void> {
+  if (window.isDestroyed() || window.isVisible()) {
+    return;
+  }
+
+  await new Promise<void>((resolve) => {
+    let settled = false;
+    const done = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      window.off('show', done);
+      window.off('closed', done);
+      resolve();
+    };
+
+    const timer = setTimeout(() => {
+      console.log('Main window not visible after timeout, showing certificate prompt anyway');
+      done();
+    }, WINDOW_VISIBLE_TIMEOUT_MS);
+
+    window.once('show', done);
+    window.once('closed', done);
+  });
+}
+
+/**
+ * Shows a message box parented to the main window when one is available, so the
+ * dialog is window-modal and visibly attached to the app rather than being a
+ * free-floating top-level window with its own taskbar entry.
+ */
+async function showDialog(
+  parentWindow: BrowserWindow | null | undefined,
+  options: Electron.MessageBoxOptions
+): Promise<Electron.MessageBoxReturnValue> {
+  if (parentWindow && !parentWindow.isDestroyed()) {
+    return dialog.showMessageBox(parentWindow, options);
+  }
+  return dialog.showMessageBox(options);
+}
+
 /**
  * Attempts to install the certificate to the system trust store
  * Returns true if successful or user dismissed, false if failed
  */
-async function installCertificate(certPath: string): Promise<boolean> {
+async function installCertificate(
+  certPath: string,
+  parentWindow?: BrowserWindow | null
+): Promise<boolean> {
   const platform = process.platform;
 
   let instructions = '';
@@ -211,7 +272,7 @@ sudo update-ca-certificates
 Certificate location: ${certPath}`;
   }
 
-  const response = await dialog.showMessageBox({
+  const response = await showDialog(parentWindow, {
     type: 'info',
     title: 'SSL Certificate Trust',
     message: 'BSV Desktop uses HTTPS for secure communication',
@@ -269,7 +330,7 @@ Certificate location: ${certPath}`;
   } catch (error) {
     console.error('Failed to install certificate:', error);
 
-    await dialog.showMessageBox({
+    await showDialog(parentWindow, {
       type: 'error',
       title: 'Certificate Installation Failed',
       message: 'Failed to install the certificate automatically.',
@@ -284,9 +345,15 @@ Certificate location: ${certPath}`;
 }
 
 /**
- * Prompts user to trust the certificate if not already trusted
+ * Prompts user to trust the certificate if not already trusted.
+ *
+ * Pass the main window so the prompt can wait for it and parent itself to it.
+ * Without that, the prompt appears before the app does on a cold start.
  */
-export async function ensureCertTrusted(certPath: string): Promise<void> {
+export async function ensureCertTrusted(
+  certPath: string,
+  parentWindow?: BrowserWindow | null
+): Promise<void> {
   const trusted = await isCertTrusted(certPath);
 
   if (trusted) {
@@ -294,8 +361,18 @@ export async function ensureCertTrusted(certPath: string): Promise<void> {
     return;
   }
 
+  // Only wait once we know we actually need to prompt — the common case is
+  // already-trusted, and that must stay a silent no-op.
+  if (parentWindow && !parentWindow.isDestroyed()) {
+    await waitForWindowVisible(parentWindow);
+    if (parentWindow.isDestroyed()) {
+      console.log('Main window closed before the certificate prompt could be shown');
+      return;
+    }
+  }
+
   console.log('Certificate not trusted, attempting to install...');
-  const success = await installCertificate(certPath);
+  const success = await installCertificate(certPath, parentWindow);
 
   if (success) {
     // Verify it actually worked

--- a/test/sslCertPrompt.test.ts
+++ b/test/sslCertPrompt.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Regression tests for when the certificate trust prompt is allowed to appear.
+ *
+ * The prompt used to pop up before the main app window did. The window is
+ * created with `show: false` and only shown on 'ready-to-show' (the renderer's
+ * first paint), while certificate work started immediately after
+ * createWindow(). On a cold start the dialog won that race, so new users met an
+ * unexplained certificate prompt floating over the desktop with no application
+ * behind it — and largely dismissed it, leaving the HTTPS substrate untrusted.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { EventEmitter } from 'events'
+import os from 'os'
+import path from 'path'
+import fs from 'fs'
+import forge from 'node-forge'
+
+const showMessageBox = vi.fn(async () => ({ response: 1, checkboxChecked: false }))
+
+vi.mock('electron', () => ({
+  app: { getPath: () => os.tmpdir() },
+  dialog: { showMessageBox },
+  BrowserWindow: class {},
+}))
+
+// Every trust lookup fails, i.e. the certificate is not trusted and the app
+// must prompt. Callback-style so promisify() wraps it the way the real one is.
+vi.mock('child_process', () => ({
+  execFile: (_cmd: string, _args: string[], cb: (err: Error) => void) => {
+    cb(new Error('NTE_NOT_FOUND'))
+  },
+}))
+
+/** Minimal stand-in for BrowserWindow covering what the prompt path touches. */
+class FakeWindow extends EventEmitter {
+  private visible = false
+  private destroyed = false
+
+  isVisible() { return this.visible }
+  isDestroyed() { return this.destroyed }
+  show() { this.visible = true; this.emit('show') }
+  destroy() { this.destroyed = true; this.emit('closed') }
+}
+
+/** Lets pending microtasks and timers settle so we can assert on "not yet". */
+const settle = async () => {
+  for (let i = 0; i < 5; i++) await new Promise((resolve) => setImmediate(resolve))
+}
+
+function writeTempCert(): string {
+  const keys = forge.pki.rsa.generateKeyPair(2048)
+  const cert = forge.pki.createCertificate()
+  cert.publicKey = keys.publicKey
+  cert.serialNumber = '01'
+  cert.validity.notBefore = new Date()
+  cert.validity.notAfter = new Date()
+  cert.validity.notAfter.setFullYear(cert.validity.notBefore.getFullYear() + 1)
+  const attrs = [
+    { name: 'commonName', value: 'localhost' },
+    { name: 'organizationName', value: 'BSV Desktop' },
+  ]
+  cert.setSubject(attrs)
+  cert.setIssuer(attrs)
+  cert.sign(keys.privateKey, forge.md.sha256.create())
+
+  const file = path.join(os.tmpdir(), `bsv-cert-prompt-test-${process.pid}-${Date.now()}.crt`)
+  fs.writeFileSync(file, forge.pki.certificateToPem(cert))
+  return file
+}
+
+let sslCert: typeof import('../electron/sslCert')
+let certPath: string
+
+describe('certificate trust prompt timing', () => {
+  beforeEach(async () => {
+    showMessageBox.mockClear()
+    sslCert = await import('../electron/sslCert')
+    certPath = writeTempCert()
+  })
+
+  it('does not prompt until the main window is visible', async () => {
+    const window = new FakeWindow()
+    const pending = sslCert.ensureCertTrusted(certPath, window as never)
+
+    await settle()
+    expect(showMessageBox).not.toHaveBeenCalled()
+
+    window.show()
+    await pending
+
+    expect(showMessageBox).toHaveBeenCalledTimes(1)
+  })
+
+  it('parents the dialog to the main window so it is not a free-floating prompt', async () => {
+    const window = new FakeWindow()
+    window.show()
+
+    await sslCert.ensureCertTrusted(certPath, window as never)
+
+    expect(showMessageBox).toHaveBeenCalledTimes(1)
+    expect(showMessageBox.mock.calls[0][0]).toBe(window)
+  })
+
+  it('prompts immediately when the window is already visible', async () => {
+    const window = new FakeWindow()
+    window.show()
+
+    const pending = sslCert.ensureCertTrusted(certPath, window as never)
+    await settle()
+
+    expect(showMessageBox).toHaveBeenCalledTimes(1)
+    await pending
+  })
+
+  it('does not prompt at all if the window is closed while still hidden', async () => {
+    const window = new FakeWindow()
+    const pending = sslCert.ensureCertTrusted(certPath, window as never)
+
+    await settle()
+    window.destroy()
+    await pending
+
+    expect(showMessageBox).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

On a cold start the certificate trust prompt appears **before** the main app window. The first thing a new user sees is an unexplained certificate dialog floating over the desktop with no application behind it — so most people dismiss it, the certificate never gets trusted, and the HTTPS connectivity substrate fails.

This reproduces on some Windows machines and not others because it is a race, and slower machines lose it more reliably.

## Root cause

Two separate problems in the startup path.

**1. Ordering.** `createWindow()` builds the window with `show: false` and only reveals it on `ready-to-show`, which waits for the renderer's first paint:

```ts
mainWindow = new BrowserWindow({ /* ... */ show: false });
mainWindow.once('ready-to-show', () => { mainWindow?.show(); });
```

`app.whenReady()` then calls `startHttpServer(mainWindow)` immediately afterwards, and that went straight into certificate work:

```ts
const { cert, key, certPath } = await generateSelfSignedCert();
await ensureCertTrusted(certPath);   // <- dialog, before the window is shown
```

The dialog therefore reliably beat the window on screen.

**2. Parenting.** `dialog.showMessageBox()` was called with no parent window, so it was a free-floating top-level dialog with its own taskbar entry rather than something visibly attached to the app. Even had the ordering been right, it would not have read as belonging to BSV Desktop.

## Fix

- `ensureCertTrusted()` / `installCertificate()` now take the main window, wait for it to actually be on screen, and parent the dialog to it.
- The wait happens **only when a prompt is actually needed**. The common already-trusted path stays a silent no-op and adds no startup latency.
- The wait times out after 15s, so a window that never paints cannot leave a user unable to trust the certificate at all.
- The prompt is no longer awaited before the servers listen. Trusting the certificate governs whether clients *accept* the HTTPS endpoint, not whether it *comes up*, so startup no longer blocks on a dialog the user might leave sitting there.
- If the window is closed while still hidden, no prompt is shown at all.

## Testing

`test/sslCertPrompt.test.ts` covers four behaviours: no prompt before the window is visible, the dialog is parented to the window, an already-visible window prompts immediately, and a window closed while hidden never prompts.

Three of the four **fail against the pre-fix code** — verified by stashing the fix and re-running:

```
× does not prompt until the main window is visible
  AssertionError: expected "spy" to not be called at all, but actually been called 1 times
× parents the dialog to the main window so it is not a free-floating prompt
  AssertionError: expected { type: 'info', …(6) } to be FakeWindow{ … }
✓ prompts immediately when the window is already visible      <- control, passes either way
× does not prompt at all if the window is closed while still hidden
```

All four pass with the fix. `tsc -p tsconfig.electron.json --noEmit` is clean.

## One related observation, deliberately not changed here

`generateSelfSignedCert()` runs `forge.pki.rsa.generateKeyPair(2048)`, which is synchronous and blocks the main process. On first launch — exactly when the prompt appears — that delays `ready-to-show` as well, widening the window this bug lived in. The ordering fix makes the race moot, so this is now a startup-latency issue rather than a correctness one. Moving it to Node's async `crypto.generateKeyPair` would be a sensible follow-up, but it touches certificate generation and did not belong in a fix aimed at prompt ordering.
