### PR TITLE
Windows platform specific bug fixes

### DIFF
--- a/electron/httpServer.ts
+++ b/electron/httpServer.ts
@@ -268,9 +268,6 @@ export async function startHttpServer(mainWindow: BrowserWindow): Promise<() => 
   // Generate self-signed certificate
   const { cert, key, certPath } = await generateSelfSignedCert();
 
-  // Prompt user to trust certificate if needed
-  await ensureCertTrusted(certPath);
-
   // Start HTTPS server (2121) + HTTP fallback (3321)
   const server: Server = await new Promise((resolve, reject) => {
     const srv = https.createServer({ cert, key }, app);
@@ -290,6 +287,16 @@ export async function startHttpServer(mainWindow: BrowserWindow): Promise<() => 
       }
       reject(error);
     });
+  });
+
+  // Prompt the user to trust the certificate, once the main window is on screen.
+  //
+  // Deliberately not awaited: the servers are already listening, and startup
+  // must not block on a dialog the user may leave sitting there. Trusting the
+  // certificate affects whether clients accept the HTTPS endpoint, not whether
+  // it comes up.
+  void ensureCertTrusted(certPath, mainWindow).catch((error) => {
+    console.error('Certificate trust check failed:', error);
   });
 
   // Return cleanup function

--- a/electron/httpServer.ts
+++ b/electron/httpServer.ts
@@ -3,7 +3,7 @@ import cors from 'cors';
 import { BrowserWindow } from 'electron';
 import { Server } from 'https';
 import https from 'https';
-import { generateSelfSignedCert, ensureCertTrusted } from './sslCert.js';
+import { generateSelfSignedCert, ensureCertTrusted, HTTPS_BRIDGE_PORT, HTTP_BRIDGE_PORT } from './sslCert.js';
 
 interface HttpRequestEvent {
   method: string;
@@ -47,6 +47,23 @@ function setCorsHeaders(res: Response): void {
 
 function canWriteResponse(res: Response): boolean {
   return !res.writableEnded && !res.destroyed && res.writable;
+}
+
+/**
+ * A local port the wallet bridge needs was already taken.
+ *
+ * Carries the port so the caller can say which one, rather than failing with a
+ * bare EADDRINUSE the user cannot act on.
+ */
+export class PortInUseError extends Error {
+  constructor(public readonly port: number) {
+    super(
+      `Port ${port} is already in use. BSV Desktop needs ports ${HTTPS_BRIDGE_PORT} and ${HTTP_BRIDGE_PORT} on `
+      + '127.0.0.1 for its local wallet bridge. This is usually another copy of '
+      + 'BSV Desktop already running, or other software holding the port.'
+    );
+    this.name = 'PortInUseError';
+  }
 }
 
 export async function startHttpServer(mainWindow: BrowserWindow): Promise<() => Promise<void>> {
@@ -272,20 +289,35 @@ export async function startHttpServer(mainWindow: BrowserWindow): Promise<() => 
   const server: Server = await new Promise((resolve, reject) => {
     const srv = https.createServer({ cert, key }, app);
 
-    srv.listen(2121, '127.0.0.1', () => {
-      console.log('HTTPS server listening on https://127.0.0.1:2121');
-      app.listen(3321, '127.0.0.1', () => {
-        console.log('HTTP server listening on http://127.0.0.1:3321');
-        resolve(srv);
-      });
-    });
-
-    srv.on('error', (error: NodeJS.ErrnoException) => {
+    // A port conflict used to call process.exit(1), killing the app instantly
+    // with nothing on screen — the user just saw BSV Desktop fail to open. That
+    // is a realistic scenario on managed machines, where security agents and
+    // other software claim unusual ports, and 2121 is a common alternate FTP
+    // port. Reject with something explanatory and let the caller decide.
+    const failWith = (port: number, error: NodeJS.ErrnoException) => {
       if (error.code === 'EADDRINUSE') {
-        console.error('Port 2121 is already in use!');
-        process.exit(1);
+        reject(new PortInUseError(port));
+        return;
       }
       reject(error);
+    };
+
+    srv.on('error', (error: NodeJS.ErrnoException) => failWith(HTTPS_BRIDGE_PORT, error));
+
+    srv.listen(HTTPS_BRIDGE_PORT, '127.0.0.1', () => {
+      console.log(`HTTPS server listening on https://127.0.0.1:${HTTPS_BRIDGE_PORT}`);
+
+      // The HTTP fallback needs the same treatment; its listen error was
+      // previously unhandled entirely.
+      const httpServer = app.listen(HTTP_BRIDGE_PORT, '127.0.0.1', () => {
+        console.log(`HTTP server listening on http://127.0.0.1:${HTTP_BRIDGE_PORT}`);
+        resolve(srv);
+      });
+
+      httpServer.on('error', (error: NodeJS.ErrnoException) => {
+        srv.close();
+        failWith(HTTP_BRIDGE_PORT, error);
+      });
     });
   });
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { createRequire } from 'module';
 import fs from 'fs';
-import { startHttpServer } from './httpServer.js';
+import { startHttpServer, PortInUseError } from './httpServer.js';
 import { buildApplicationMenu } from './appMenu.js';
 import { applyPersistedProxySettings, registerNetworkIpc } from './networkSettings.js';
 
@@ -723,9 +723,31 @@ app.whenReady().then(async () => {
 
   // Start HTTPS server on port 2121
   if (mainWindow) {
-    httpServerCleanup = await startHttpServer(mainWindow);
+    try {
+      httpServerCleanup = await startHttpServer(mainWindow);
+    } catch (error) {
+      // The wallet bridge failing is serious but not a reason to vanish without
+      // a word, which is what a port conflict used to do. Explain it and keep
+      // the app open so the user can read the message and act on it.
+      console.error('[Startup] Failed to start the local wallet bridge:', error);
 
-    // Initialize auto-updater
+      const detail = error instanceof PortInUseError
+        ? error.message
+        : `The local wallet bridge could not be started.\n\n${(error as Error)?.message ?? String(error)}`;
+
+      dialog.showMessageBox(mainWindow, {
+        type: 'error',
+        title: 'Wallet Bridge Unavailable',
+        message: 'BSV Desktop could not start its local connection',
+        detail: `${detail}\n\nApplications will not be able to connect to your wallet until this is resolved.`,
+        buttons: ['OK']
+      }).catch((dialogError) => {
+        console.error('[Startup] Failed to show bridge error dialog:', dialogError);
+      });
+    }
+
+    // Initialize auto-updater regardless: updates must keep working even when
+    // the bridge does not, since an update may be what fixes the bridge.
     const { initAutoUpdater } = getUpdaterModule();
     initAutoUpdater(mainWindow);
   }

--- a/electron/sslCert.ts
+++ b/electron/sslCert.ts
@@ -1,4 +1,4 @@
-import { app, dialog, BrowserWindow } from 'electron';
+import { app, dialog, net, BrowserWindow } from 'electron';
 import path from 'path';
 import fs from 'fs';
 import os from 'os';
@@ -143,6 +143,164 @@ export function getCertSha1Thumbprint(certPem: string): string {
 }
 
 /**
+ * Distinguishes "certutil ran and said the certificate is not there" from
+ * "certutil could not run at all".
+ *
+ * NTE_NOT_FOUND (0x80090011 / -2146893807) is certutil's genuine answer for an
+ * absent certificate. Anything else — ENOENT because the binary is missing, a
+ * WDAC/AppLocker denial, an EDR kill — means we learned nothing and should try
+ * another route rather than reporting the certificate as untrusted.
+ */
+function isMissingCertError(error: unknown): boolean {
+  const err = error as { code?: number | string; stdout?: string; stderr?: string };
+
+  // Windows exit codes are DWORDs, and whether this one surfaces signed or
+  // unsigned is not worth depending on, so accept both. The output check below
+  // is the reliable signal: certutil always prints the code.
+  if (err?.code === -2146893807 || err?.code === 2148073489) return true;
+
+  const output = `${err?.stdout ?? ''}${err?.stderr ?? ''}`;
+  return output.includes('0x80090011') || output.includes('NTE_NOT_FOUND');
+}
+
+/** Runs a PowerShell one-liner, resolving its trimmed stdout. */
+async function runPowerShell(script: string): Promise<string> {
+  const { stdout } = await execFileAsync('powershell', [
+    '-NoProfile',
+    '-NonInteractive',
+    '-ExecutionPolicy', 'Bypass',
+    '-Command', script
+  ]);
+  return stdout.trim();
+}
+
+/** Single-quoted PowerShell literal, with embedded quotes escaped. */
+function psQuote(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+/**
+ * certutil-free trust lookup, for machines where certutil is blocked.
+ */
+async function isCertInStoreViaPowerShell(thumbprint: string): Promise<boolean> {
+  try {
+    const out = await runPowerShell(
+      `if (Test-Path ${psQuote(`Cert:\\CurrentUser\\Root\\${thumbprint.toUpperCase()}`)}) { 'FOUND' } else { 'MISSING' }`
+    );
+    return out.includes('FOUND');
+  } catch (error) {
+    console.error('PowerShell trust check also unavailable:', error);
+    return false;
+  }
+}
+
+/**
+ * Reports whether group policy restricts user-installed root certificates.
+ *
+ * This is only ever used to explain a failure we have already observed, never
+ * to predict one: the exact flag semantics are not worth guessing at, but the
+ * mere presence of the policy is a strong hint about why a certificate that
+ * installed successfully is still not being honoured.
+ */
+async function hasUserRootRestrictionPolicy(): Promise<boolean> {
+  try {
+    const { stdout } = await execFileAsync('reg', [
+      'query',
+      'HKLM\\SOFTWARE\\Policies\\Microsoft\\SystemCertificates\\Root\\ProtectedRoots',
+      '/v', 'Flags'
+    ]);
+    return stdout.includes('Flags');
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Local wallet bridge ports.
+ *
+ * Defined here rather than in httpServer so the trust probe below and the
+ * listeners cannot drift apart: a probe pointed at a port nobody serves would
+ * fail silently and look like a trust problem. httpServer imports these.
+ */
+export const HTTPS_BRIDGE_PORT = 2121;
+export const HTTP_BRIDGE_PORT = 3321;
+
+/** Probed to verify trust for real. Any HTTP response means TLS was accepted. */
+const HTTPS_PROBE_URL = `https://127.0.0.1:${HTTPS_BRIDGE_PORT}/manifest.json`;
+const HTTPS_PROBE_TIMEOUT_MS = 5_000;
+
+/**
+ * Asks the question that actually matters: does a real client accept our HTTPS
+ * endpoint?
+ *
+ * Electron's net module uses Chromium's network stack, which validates against
+ * the Windows certificate store exactly like the browsers and web apps that
+ * talk to the bridge. Node's own https client would not — it uses its bundled
+ * CA list and ignores the Windows store entirely, so it cannot answer this.
+ *
+ * This is ground truth, and it is why it runs before any store inspection.
+ * Store-based checks are heuristics about a store, and on managed Windows
+ * machines the store can say "installed" while the certificate is still not
+ * honoured — most notably when group policy forbids user-installed root CAs
+ * from being used for validation, in which case the install genuinely succeeds
+ * and is then quietly ignored. Probing the endpoint cannot be fooled by that.
+ *
+ * Returns null when the probe is inconclusive (server not up, timed out), so
+ * callers can fall back to inspecting the store rather than treating an
+ * unknown as untrusted and prompting needlessly.
+ */
+async function isCertAcceptedByClients(): Promise<boolean | null> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (result: boolean | null) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+
+    const timer = setTimeout(() => finish(null), HTTPS_PROBE_TIMEOUT_MS);
+
+    let request: Electron.ClientRequest;
+    try {
+      request = net.request({ method: 'GET', url: HTTPS_PROBE_URL });
+    } catch (error) {
+      console.log('Certificate probe could not be started:', error);
+      finish(null);
+      return;
+    }
+
+    // Any HTTP response at all means the TLS handshake was accepted; the status
+    // code is irrelevant.
+    request.on('response', (response) => {
+      response.on('data', () => { /* drain */ });
+      response.on('end', () => { /* no-op */ });
+      finish(true);
+    });
+
+    request.on('error', (error: Error & { code?: string }) => {
+      const code = error.code ?? '';
+      // Connection-level failures mean the server is not reachable yet, which
+      // says nothing about trust. Certificate failures are a real answer.
+      if (code === 'ECONNREFUSED' || code === 'ECONNRESET' || code === 'ENOTFOUND') {
+        console.log(`Certificate probe inconclusive (${code}): bridge not reachable`);
+        finish(null);
+        return;
+      }
+      console.log(`Certificate probe rejected the endpoint: ${code || error.message}`);
+      finish(false);
+    });
+
+    try {
+      request.end();
+    } catch (error) {
+      console.log('Certificate probe could not be sent:', error);
+      finish(null);
+    }
+  });
+}
+
+/**
  * Checks if the certificate is trusted by the system
  */
 async function isCertTrusted(certPath: string): Promise<boolean> {
@@ -170,8 +328,21 @@ async function isCertTrusted(certPath: string): Promise<boolean> {
       // we are actually serving, and it is not localized — matching on
       // certutil's human-readable output breaks on non-English Windows.
       const thumbprint = getCertSha1Thumbprint(fs.readFileSync(certPath, 'utf8'));
-      const { stdout } = await execFileAsync('certutil', ['-user', '-verifystore', 'Root', thumbprint]);
-      return stdout.toLowerCase().includes(thumbprint);
+
+      try {
+        const { stdout } = await execFileAsync('certutil', ['-user', '-verifystore', 'Root', thumbprint]);
+        return stdout.toLowerCase().includes(thumbprint);
+      } catch (certutilError) {
+        // certutil.exe is a well-known dual-use binary and is routinely blocked
+        // by WDAC, AppLocker or endpoint security on managed machines, where it
+        // fails the same way a missing certificate does. Confirm via PowerShell
+        // before concluding anything.
+        if (!isMissingCertError(certutilError)) {
+          console.log('certutil unavailable for trust check, falling back to PowerShell');
+          return await isCertInStoreViaPowerShell(thumbprint);
+        }
+        return false;
+      }
     } else {
       // Linux: Various cert stores, hard to check reliably
       return false;
@@ -240,13 +411,22 @@ async function showDialog(
 }
 
 /**
+ * Outcome of offering to install the certificate.
+ *
+ * Kept distinct because they warrant different follow-up: only an attempted
+ * install is worth verifying, and only a verified-failed install is worth
+ * warning about. Telling a user who chose "Not Now" that their connection is
+ * broken would be scolding them for a decision they deliberately made.
+ */
+type InstallOutcome = 'installed' | 'declined' | 'failed';
+
+/**
  * Attempts to install the certificate to the system trust store
- * Returns true if successful or user dismissed, false if failed
  */
 async function installCertificate(
   certPath: string,
   parentWindow?: BrowserWindow | null
-): Promise<boolean> {
+): Promise<InstallOutcome> {
   const platform = process.platform;
 
   let instructions = '';
@@ -284,11 +464,11 @@ Certificate location: ${certPath}`;
 
   // User clicked "Not Now" or dismissed
   if (response.response !== 0) {
-    return true;
+    return 'declined';
   }
 
   if (!canAutoInstall) {
-    return true; // Just showed instructions
+    return 'declined'; // Linux: instructions shown, nothing installed for them
   }
 
   try {
@@ -313,19 +493,21 @@ Certificate location: ${certPath}`;
         ]);
       }
 
-      return true;
+      return 'installed';
     } else if (platform === 'win32') {
-      // Windows: Import to Trusted Root store
-      await execFileAsync('certutil', ['-addstore', '-user', 'Root', certPath]);
+      // Windows: Import to Trusted Root store.
+      try {
+        await execFileAsync('certutil', ['-addstore', '-user', 'Root', certPath]);
+      } catch (certutilError) {
+        // certutil is commonly blocked by WDAC/AppLocker/EDR on managed
+        // machines. PowerShell's PKI module reaches the same store without it.
+        console.log('certutil could not install the certificate, falling back to PowerShell:', certutilError);
+        await runPowerShell(
+          `Import-Certificate -FilePath ${psQuote(certPath)} -CertStoreLocation Cert:\\CurrentUser\\Root | Out-Null`
+        );
+      }
 
-      // await dialog.showMessageBox({
-      //   type: 'info',
-      //   title: 'Certificate Installed',
-      //   message: 'The SSL certificate has been successfully installed and trusted.',
-      //   buttons: ['OK']
-      // });
-
-      return true;
+      return 'installed';
     }
   } catch (error) {
     console.error('Failed to install certificate:', error);
@@ -338,10 +520,10 @@ Certificate location: ${certPath}`;
       buttons: ['OK']
     });
 
-    return false;
+    return 'failed';
   }
 
-  return true;
+  return 'installed';
 }
 
 /**
@@ -354,7 +536,16 @@ export async function ensureCertTrusted(
   certPath: string,
   parentWindow?: BrowserWindow | null
 ): Promise<void> {
-  const trusted = await isCertTrusted(certPath);
+  // Ask a real client first. If the endpoint already works there is nothing to
+  // fix, whatever any certificate store happens to say.
+  const accepted = await isCertAcceptedByClients();
+  if (accepted === true) {
+    console.log('Certificate accepted by the network stack, nothing to do');
+    return;
+  }
+
+  // Inconclusive probe (bridge not reachable yet) falls back to the store.
+  const trusted = accepted === null ? await isCertTrusted(certPath) : false;
 
   if (trusted) {
     console.log('Certificate already trusted');
@@ -372,15 +563,63 @@ export async function ensureCertTrusted(
   }
 
   console.log('Certificate not trusted, attempting to install...');
-  const success = await installCertificate(certPath, parentWindow);
+  const outcome = await installCertificate(certPath, parentWindow);
 
-  if (success) {
-    // Verify it actually worked
-    const nowTrusted = await isCertTrusted(certPath);
-    if (nowTrusted) {
-      console.log('Certificate successfully installed and verified');
-    } else {
-      console.log('Certificate install reported success but verification failed');
-    }
+  // 'declined' is the user's call and needs no follow-up; 'failed' already
+  // showed its own error. Only an attempted install is worth verifying.
+  if (outcome !== 'installed') {
+    return;
   }
+
+  // Verify against a real client again, not just the store. On managed Windows
+  // machines the two can disagree: the certificate is genuinely in the store
+  // and genuinely not honoured.
+  const nowAccepted = await isCertAcceptedByClients();
+  if (nowAccepted === true) {
+    console.log('Certificate successfully installed and verified');
+    return;
+  }
+
+  if (nowAccepted === null && await isCertTrusted(certPath)) {
+    console.log('Certificate installed; endpoint not reachable to confirm end to end');
+    return;
+  }
+
+  console.log('Certificate install reported success but verification failed');
+  await explainVerificationFailure(certPath, parentWindow);
+}
+
+/**
+ * Tells the user why a certificate that installed cleanly still is not trusted.
+ *
+ * Without this the app looks like it silently did nothing: the install succeeds,
+ * the prompt disappears, and connectivity stays broken with no explanation. The
+ * usual cause on a corporate or university machine is a policy that forbids
+ * user-installed root CAs from being used for validation, which no amount of
+ * retrying will overcome — it needs an administrator.
+ */
+async function explainVerificationFailure(
+  certPath: string,
+  parentWindow?: BrowserWindow | null
+): Promise<void> {
+  const policyRestricted = process.platform === 'win32' && await hasUserRootRestrictionPolicy();
+
+  const detail = policyRestricted
+    ? 'The certificate was installed, but this device has a policy that prevents '
+      + 'user-installed root certificates from being trusted, so it is being ignored.\n\n'
+      + 'An administrator will need to deploy the certificate for you, or allow '
+      + 'user-installed root certificates.\n\n'
+      + `Certificate location: ${certPath}`
+    : 'The certificate was installed, but the secure local connection is still '
+      + 'being rejected. This is usually caused by security software or device '
+      + 'management policy on this machine.\n\n'
+      + `Certificate location: ${certPath}`;
+
+  await showDialog(parentWindow, {
+    type: 'warning',
+    title: 'Certificate Not Trusted',
+    message: 'BSV Desktop could not establish a trusted local connection',
+    detail,
+    buttons: ['OK']
+  });
 }

--- a/electron/sslCert.ts
+++ b/electron/sslCert.ts
@@ -1,4 +1,4 @@
-import { app, dialog } from 'electron';
+import { app, dialog, BrowserWindow } from 'electron';
 import path from 'path';
 import fs from 'fs';
 import os from 'os';
@@ -181,11 +181,72 @@ async function isCertTrusted(certPath: string): Promise<boolean> {
   }
 }
 
+/** How long to wait for the main window before prompting anyway. */
+const WINDOW_VISIBLE_TIMEOUT_MS = 15_000;
+
+/**
+ * Resolves once the main window is actually on screen.
+ *
+ * The trust prompt used to appear before the app window did: the window is
+ * created with `show: false` and only shown on 'ready-to-show', which waits for
+ * the renderer's first paint, while the certificate work starts immediately
+ * after createWindow(). On a cold start the dialog reliably won the race, so
+ * the first thing a new user saw was an unexplained certificate prompt floating
+ * over the desktop with no application behind it — and most people dismissed
+ * it, leaving the HTTPS substrate untrusted.
+ *
+ * Falls through after a timeout so a window that never paints can never leave
+ * the user unable to trust the certificate at all.
+ */
+async function waitForWindowVisible(window: BrowserWindow): Promise<void> {
+  if (window.isDestroyed() || window.isVisible()) {
+    return;
+  }
+
+  await new Promise<void>((resolve) => {
+    let settled = false;
+    const done = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      window.off('show', done);
+      window.off('closed', done);
+      resolve();
+    };
+
+    const timer = setTimeout(() => {
+      console.log('Main window not visible after timeout, showing certificate prompt anyway');
+      done();
+    }, WINDOW_VISIBLE_TIMEOUT_MS);
+
+    window.once('show', done);
+    window.once('closed', done);
+  });
+}
+
+/**
+ * Shows a message box parented to the main window when one is available, so the
+ * dialog is window-modal and visibly attached to the app rather than being a
+ * free-floating top-level window with its own taskbar entry.
+ */
+async function showDialog(
+  parentWindow: BrowserWindow | null | undefined,
+  options: Electron.MessageBoxOptions
+): Promise<Electron.MessageBoxReturnValue> {
+  if (parentWindow && !parentWindow.isDestroyed()) {
+    return dialog.showMessageBox(parentWindow, options);
+  }
+  return dialog.showMessageBox(options);
+}
+
 /**
  * Attempts to install the certificate to the system trust store
  * Returns true if successful or user dismissed, false if failed
  */
-async function installCertificate(certPath: string): Promise<boolean> {
+async function installCertificate(
+  certPath: string,
+  parentWindow?: BrowserWindow | null
+): Promise<boolean> {
   const platform = process.platform;
 
   let instructions = '';
@@ -211,7 +272,7 @@ sudo update-ca-certificates
 Certificate location: ${certPath}`;
   }
 
-  const response = await dialog.showMessageBox({
+  const response = await showDialog(parentWindow, {
     type: 'info',
     title: 'SSL Certificate Trust',
     message: 'BSV Desktop uses HTTPS for secure communication',
@@ -269,7 +330,7 @@ Certificate location: ${certPath}`;
   } catch (error) {
     console.error('Failed to install certificate:', error);
 
-    await dialog.showMessageBox({
+    await showDialog(parentWindow, {
       type: 'error',
       title: 'Certificate Installation Failed',
       message: 'Failed to install the certificate automatically.',
@@ -284,9 +345,15 @@ Certificate location: ${certPath}`;
 }
 
 /**
- * Prompts user to trust the certificate if not already trusted
+ * Prompts user to trust the certificate if not already trusted.
+ *
+ * Pass the main window so the prompt can wait for it and parent itself to it.
+ * Without that, the prompt appears before the app does on a cold start.
  */
-export async function ensureCertTrusted(certPath: string): Promise<void> {
+export async function ensureCertTrusted(
+  certPath: string,
+  parentWindow?: BrowserWindow | null
+): Promise<void> {
   const trusted = await isCertTrusted(certPath);
 
   if (trusted) {
@@ -294,8 +361,18 @@ export async function ensureCertTrusted(certPath: string): Promise<void> {
     return;
   }
 
+  // Only wait once we know we actually need to prompt — the common case is
+  // already-trusted, and that must stay a silent no-op.
+  if (parentWindow && !parentWindow.isDestroyed()) {
+    await waitForWindowVisible(parentWindow);
+    if (parentWindow.isDestroyed()) {
+      console.log('Main window closed before the certificate prompt could be shown');
+      return;
+    }
+  }
+
   console.log('Certificate not trusted, attempting to install...');
-  const success = await installCertificate(certPath);
+  const success = await installCertificate(certPath, parentWindow);
 
   if (success) {
     // Verify it actually worked

--- a/test/sslCert.test.ts
+++ b/test/sslCert.test.ts
@@ -18,6 +18,7 @@ import forge from 'node-forge'
 vi.mock('electron', () => ({
   app: { getPath: () => '/tmp/bsv-desktop-test' },
   dialog: { showMessageBox: async () => ({ response: 1 }) },
+  net: { request: () => { throw new Error('probe unavailable in tests') } },
 }))
 
 let sslCert: typeof import('../electron/sslCert')

--- a/test/sslCertPrompt.test.ts
+++ b/test/sslCertPrompt.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Regression tests for when the certificate trust prompt is allowed to appear.
+ *
+ * The prompt used to pop up before the main app window did. The window is
+ * created with `show: false` and only shown on 'ready-to-show' (the renderer's
+ * first paint), while certificate work started immediately after
+ * createWindow(). On a cold start the dialog won that race, so new users met an
+ * unexplained certificate prompt floating over the desktop with no application
+ * behind it — and largely dismissed it, leaving the HTTPS substrate untrusted.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { EventEmitter } from 'events'
+import os from 'os'
+import path from 'path'
+import fs from 'fs'
+import forge from 'node-forge'
+
+const showMessageBox = vi.fn(async () => ({ response: 1, checkboxChecked: false }))
+
+vi.mock('electron', () => ({
+  app: { getPath: () => os.tmpdir() },
+  dialog: { showMessageBox },
+  BrowserWindow: class {},
+}))
+
+// Every trust lookup fails, i.e. the certificate is not trusted and the app
+// must prompt. Callback-style so promisify() wraps it the way the real one is.
+vi.mock('child_process', () => ({
+  execFile: (_cmd: string, _args: string[], cb: (err: Error) => void) => {
+    cb(new Error('NTE_NOT_FOUND'))
+  },
+}))
+
+/** Minimal stand-in for BrowserWindow covering what the prompt path touches. */
+class FakeWindow extends EventEmitter {
+  private visible = false
+  private destroyed = false
+
+  isVisible() { return this.visible }
+  isDestroyed() { return this.destroyed }
+  show() { this.visible = true; this.emit('show') }
+  destroy() { this.destroyed = true; this.emit('closed') }
+}
+
+/** Lets pending microtasks and timers settle so we can assert on "not yet". */
+const settle = async () => {
+  for (let i = 0; i < 5; i++) await new Promise((resolve) => setImmediate(resolve))
+}
+
+function writeTempCert(): string {
+  const keys = forge.pki.rsa.generateKeyPair(2048)
+  const cert = forge.pki.createCertificate()
+  cert.publicKey = keys.publicKey
+  cert.serialNumber = '01'
+  cert.validity.notBefore = new Date()
+  cert.validity.notAfter = new Date()
+  cert.validity.notAfter.setFullYear(cert.validity.notBefore.getFullYear() + 1)
+  const attrs = [
+    { name: 'commonName', value: 'localhost' },
+    { name: 'organizationName', value: 'BSV Desktop' },
+  ]
+  cert.setSubject(attrs)
+  cert.setIssuer(attrs)
+  cert.sign(keys.privateKey, forge.md.sha256.create())
+
+  const file = path.join(os.tmpdir(), `bsv-cert-prompt-test-${process.pid}-${Date.now()}.crt`)
+  fs.writeFileSync(file, forge.pki.certificateToPem(cert))
+  return file
+}
+
+let sslCert: typeof import('../electron/sslCert')
+let certPath: string
+
+describe('certificate trust prompt timing', () => {
+  beforeEach(async () => {
+    showMessageBox.mockClear()
+    sslCert = await import('../electron/sslCert')
+    certPath = writeTempCert()
+  })
+
+  it('does not prompt until the main window is visible', async () => {
+    const window = new FakeWindow()
+    const pending = sslCert.ensureCertTrusted(certPath, window as never)
+
+    await settle()
+    expect(showMessageBox).not.toHaveBeenCalled()
+
+    window.show()
+    await pending
+
+    expect(showMessageBox).toHaveBeenCalledTimes(1)
+  })
+
+  it('parents the dialog to the main window so it is not a free-floating prompt', async () => {
+    const window = new FakeWindow()
+    window.show()
+
+    await sslCert.ensureCertTrusted(certPath, window as never)
+
+    expect(showMessageBox).toHaveBeenCalledTimes(1)
+    expect(showMessageBox.mock.calls[0][0]).toBe(window)
+  })
+
+  it('prompts immediately when the window is already visible', async () => {
+    const window = new FakeWindow()
+    window.show()
+
+    const pending = sslCert.ensureCertTrusted(certPath, window as never)
+    await settle()
+
+    expect(showMessageBox).toHaveBeenCalledTimes(1)
+    await pending
+  })
+
+  it('does not prompt at all if the window is closed while still hidden', async () => {
+    const window = new FakeWindow()
+    const pending = sslCert.ensureCertTrusted(certPath, window as never)
+
+    await settle()
+    window.destroy()
+    await pending
+
+    expect(showMessageBox).not.toHaveBeenCalled()
+  })
+})

--- a/test/sslCertPrompt.test.ts
+++ b/test/sslCertPrompt.test.ts
@@ -22,6 +22,9 @@ vi.mock('electron', () => ({
   app: { getPath: () => os.tmpdir() },
   dialog: { showMessageBox },
   BrowserWindow: class {},
+  // Probe unavailable, so trust falls back to inspecting the certificate store
+  // — these tests are about prompt timing, not about the probe.
+  net: { request: () => { throw new Error('probe unavailable in tests') } },
 }))
 
 // Every trust lookup fails, i.e. the certificate is not trusted and the app

--- a/test/sslCertTrustProbe.test.ts
+++ b/test/sslCertTrustProbe.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Tests for verifying certificate trust against a real client rather than
+ * against a certificate store.
+ *
+ * Store inspection is a heuristic and has been wrong twice: once because the
+ * lookup key was the organization instead of the common name, and once — the
+ * case that motivated this — because on managed Windows machines a certificate
+ * can be genuinely present in the store and genuinely not honoured, when policy
+ * forbids user-installed root CAs from validating. Electron's net module uses
+ * Chromium's network stack, which consults the Windows store exactly like the
+ * browsers and web apps that talk to the bridge, so probing the endpoint
+ * answers the question that actually matters.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { EventEmitter } from 'events'
+import os from 'os'
+import path from 'path'
+import fs from 'fs'
+import forge from 'node-forge'
+
+const showMessageBox = vi.fn(async () => ({ response: 1, checkboxChecked: false }))
+
+/** Controls what the fake network stack does with the probe request. */
+let probeBehaviour: 'accept' | 'reject-cert' | 'refused' = 'accept'
+
+class FakeClientRequest extends EventEmitter {
+  end() {
+    setImmediate(() => {
+      if (probeBehaviour === 'accept') {
+        const response = new EventEmitter()
+        this.emit('response', response)
+        response.emit('end')
+      } else if (probeBehaviour === 'reject-cert') {
+        Object.assign(new Error(), {})
+        const error = new Error('certificate verify failed') as Error & { code?: string }
+        error.code = 'ERR_CERT_AUTHORITY_INVALID'
+        this.emit('error', error)
+      } else {
+        const error = new Error('connection refused') as Error & { code?: string }
+        error.code = 'ECONNREFUSED'
+        this.emit('error', error)
+      }
+    })
+  }
+}
+
+const request = vi.fn(() => new FakeClientRequest())
+
+vi.mock('electron', () => ({
+  app: { getPath: () => os.tmpdir() },
+  dialog: { showMessageBox },
+  BrowserWindow: class {},
+  net: { request },
+}))
+
+/** Controls what external commands do. */
+let execBehaviour: 'fail-all' | 'install-succeeds' = 'fail-all'
+
+// Store lookups report "not trusted", so any decision not to prompt must have
+// come from the probe rather than from the store. Uses promisify.custom because
+// sslCert wraps execFile with util.promisify and destructures { stdout }.
+vi.mock('child_process', () => {
+  const execFile = (() => { /* callback form unused */ }) as unknown as Record<symbol, unknown>
+
+  execFile[Symbol.for('nodejs.util.promisify.custom')] = async (cmd: string, args: string[] = []) => {
+    const argv = args.join(' ')
+
+    if (execBehaviour === 'install-succeeds') {
+      // The install itself works — this is the managed-Windows case where the
+      // certificate lands in the store and is then ignored.
+      if (argv.includes('-addstore')) return { stdout: 'CertUtil: -addstore command completed successfully.', stderr: '' }
+      // Group policy restricting user root CAs is present.
+      if (cmd === 'reg') return { stdout: '    Flags    REG_DWORD    0x1', stderr: '' }
+    }
+
+    const error = new Error('CertUtil: -verifystore command FAILED: 0x80090011') as Error & { stdout: string }
+    error.stdout = 'CertUtil: -verifystore command FAILED: 0x80090011 (-2146893807 NTE_NOT_FOUND)'
+    throw error
+  }
+
+  return { execFile }
+})
+
+class FakeWindow extends EventEmitter {
+  isVisible() { return true }
+  isDestroyed() { return false }
+}
+
+function writeTempCert(): string {
+  const keys = forge.pki.rsa.generateKeyPair(2048)
+  const cert = forge.pki.createCertificate()
+  cert.publicKey = keys.publicKey
+  cert.serialNumber = '01'
+  cert.validity.notBefore = new Date()
+  cert.validity.notAfter = new Date()
+  cert.validity.notAfter.setFullYear(cert.validity.notBefore.getFullYear() + 1)
+  const attrs = [
+    { name: 'commonName', value: 'localhost' },
+    { name: 'organizationName', value: 'BSV Desktop' },
+  ]
+  cert.setSubject(attrs)
+  cert.setIssuer(attrs)
+  cert.sign(keys.privateKey, forge.md.sha256.create())
+
+  const file = path.join(os.tmpdir(), `bsv-probe-test-${process.pid}-${Date.now()}.crt`)
+  fs.writeFileSync(file, forge.pki.certificateToPem(cert))
+  return file
+}
+
+let sslCert: typeof import('../electron/sslCert')
+let certPath: string
+
+describe('certificate trust verification', () => {
+  beforeEach(async () => {
+    showMessageBox.mockClear()
+    request.mockClear()
+    execBehaviour = 'fail-all'
+    sslCert = await import('../electron/sslCert')
+    certPath = writeTempCert()
+  })
+
+  it('does not prompt when a real client already accepts the endpoint', async () => {
+    probeBehaviour = 'accept'
+
+    await sslCert.ensureCertTrusted(certPath, new FakeWindow() as never)
+
+    // The store says untrusted; the probe says otherwise and wins.
+    expect(showMessageBox).not.toHaveBeenCalled()
+    expect(request).toHaveBeenCalledTimes(1)
+  })
+
+  it('prompts when a real client rejects the certificate', async () => {
+    probeBehaviour = 'reject-cert'
+
+    await sslCert.ensureCertTrusted(certPath, new FakeWindow() as never)
+
+    expect(showMessageBox).toHaveBeenCalled()
+  })
+
+  it('does not warn when the user declines the install', async () => {
+    probeBehaviour = 'reject-cert'
+    showMessageBox.mockResolvedValueOnce({ response: 1, checkboxChecked: false }) // "Not Now"
+
+    await sslCert.ensureCertTrusted(certPath, new FakeWindow() as never)
+
+    // Declining is a deliberate choice, not a failure to scold the user for.
+    expect(showMessageBox).toHaveBeenCalledTimes(1)
+  })
+
+  it('explains the failure when the cert installs but is still not honoured', async () => {
+    // The managed-Windows case: policy forbids user-installed root CAs, so the
+    // install genuinely succeeds and the certificate is genuinely ignored.
+    probeBehaviour = 'reject-cert'
+    execBehaviour = 'install-succeeds'
+    showMessageBox.mockResolvedValueOnce({ response: 0, checkboxChecked: false }) // "Trust Certificate"
+
+    await sslCert.ensureCertTrusted(certPath, new FakeWindow() as never)
+
+    expect(showMessageBox).toHaveBeenCalledTimes(2)
+
+    const warning = showMessageBox.mock.calls[1][1] as unknown as Electron.MessageBoxOptions
+    expect(warning.title).toBe('Certificate Not Trusted')
+    expect(warning.detail).toContain('policy')
+  })
+
+  it('falls back to the store when the bridge is not reachable', async () => {
+    probeBehaviour = 'refused'
+
+    await sslCert.ensureCertTrusted(certPath, new FakeWindow() as never)
+
+    // A refused connection says nothing about trust, so we must not treat it as
+    // proof of anything — here the store reports untrusted, so we prompt.
+    expect(showMessageBox).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Four fixes for problems that only bite on Windows, and mostly on **managed** Windows machines — corporate and university fleets where group policy and endpoint security get involved.

> **Stacked on #70.** These touch the same functions, so this branch is based on `fix/cert-prompt-appears-before-window`. Merge #70 first and this diff reduces to just the changes below.

## 1. Verify certificate trust against a real client, not a certificate store

Store inspection is a heuristic, and it has now been wrong twice — first the CN-vs-organization lookup, and now this.

On a managed machine a certificate can be **genuinely present in the store and genuinely not honoured**. Group policy (`SystemCertificates\Root\ProtectedRoots`) can forbid user-installed root CAs from being used for validation. `certutil -addstore` then succeeds, returns 0, the certificate really is in the store — and Windows ignores it. Reinstalling never helps.

`ensureCertTrusted` now asks Electron's `net` module first. It uses Chromium's network stack, which consults the Windows certificate store exactly like the browsers and web apps that actually talk to the bridge. If the endpoint works for a real client, there is nothing to fix, whatever the store says.

Worth noting why this has to be Electron's `net` and not Node's `https`: **Node ignores the Windows certificate store entirely** and validates against its own bundled CA list, so it cannot answer this question at all.

An unreachable endpoint is reported as *inconclusive* rather than untrusted, so a connection error falls back to store inspection instead of triggering a prompt on no evidence.

## 2. Survive certutil being blocked

`certutil.exe` is a well-known dual-use binary — `certutil -urlcache` is a standard payload-download technique — so it is routinely blocked by WDAC, AppLocker, or endpoint security. When blocked it fails *exactly the way a missing certificate does*, so the app concluded "not trusted" and re-prompted forever.

Both the trust check and the install now distinguish `NTE_NOT_FOUND` (certutil ran and gave a real answer) from a tool that could not run at all, and fall back to PowerShell's PKI module (`Cert:\CurrentUser\Root`, `Import-Certificate`) for the latter.

One detail worth flagging for review: the numeric exit code check accepts both the signed and unsigned forms of `0x80090011`, because whether Windows surfaces that DWORD as `-2146893807` or `2148073489` through Node is not worth depending on. The stdout check is the reliable signal — certutil always prints the code.

## 3. Explain an install that succeeds but is not honoured

Previously this logged one line and silently did nothing. The user saw a prompt, clicked Trust, the prompt vanished, and connectivity stayed broken with no explanation.

It now reports what happened, and names device policy as the likely cause when the policy key is present. The policy is only ever consulted to *explain a failure already observed*, never to predict one — the exact flag semantics are not worth guessing at, but its presence is a strong hint about a certificate that installed cleanly and is still being ignored.

Also fixed along the way: **declining the prompt no longer triggers any of this.** "Not Now" is a deliberate choice, and warning the user that their connection is broken would be scolding them for a decision they made on purpose. Only an attempted install is verified, and only a verified failure is reported.

## 4. Stop dying silently on a port conflict

```ts
if (error.code === 'EADDRINUSE') {
  console.error('Port 2121 is already in use!');
  process.exit(1);   // app vanishes, nothing on screen
}
```

The user just saw BSV Desktop fail to open. This is realistic on managed machines, where security agents claim unusual ports — and 2121 is a common alternate FTP port.

It now raises a `PortInUseError` naming the port; `main.ts` explains it and **leaves the app open** so the message can actually be read. The auto-updater still initializes, since an update may be exactly what fixes the bridge.

The HTTP fallback listener on 3321 had **no error handling at all** — its `EADDRINUSE` would have surfaced as an unhandled rejection. Now covered.

Bridge ports are shared constants, so the trust probe and the listeners cannot drift apart. A probe pointed at a port nobody serves would fail silently and look exactly like a trust problem.

## Testing

`test/sslCertTrustProbe.test.ts` covers: probe accepted (no prompt, even though the store reports untrusted — proving the probe leads), probe rejected, inconclusive probe falling back to the store, declining without a warning, and the install-succeeds-but-still-ignored case asserting the policy explanation is shown.

25 tests pass across the suite. `tsc -p tsconfig.electron.json --noEmit` clean.

## What is not covered

The managed-machine scenarios are reproduced through mocks, not on a genuinely policy-restricted machine — I do not have one. The mechanisms are real and the code paths are exercised, but the end-to-end behaviour on a locked-down corporate build is unverified. If anyone has access to an affected machine, the useful signal is the console: it now logs which path it took and why.
