### PR TITLE
fix(linux): use the BSV Desktop icon for the AppImage instead of a fallback

### DIFF
--- a/electron/linuxDesktopIntegration.ts
+++ b/electron/linuxDesktopIntegration.ts
@@ -1,0 +1,96 @@
+import { app } from 'electron';
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+
+/**
+ * Desktop integration for the Linux AppImage build.
+ *
+ * An AppImage is a single self-contained file. Nothing installs its .desktop
+ * entry or its icon, so the desktop environment has no record of the app at
+ * all. Under Wayland there is no protocol for a client to set its own window
+ * icon — the compositor matches the toplevel's app_id against installed
+ * .desktop files and uses the Icon= from there. With no installed entry, GNOME
+ * falls back to a generic icon.
+ *
+ * The app_id is derived from the executable name, which comes from the
+ * package.json `name` field: "bsv-desktop-electron". The .desktop file must be
+ * named to match for the compositor to associate the two.
+ */
+
+const APP_ID = 'bsv-desktop-electron';
+const ICON_SIZE = '512x512';
+
+const dataHome = process.env.XDG_DATA_HOME || path.join(os.homedir(), '.local', 'share');
+const desktopFilePath = path.join(dataHome, 'applications', `${APP_ID}.desktop`);
+const iconDir = path.join(dataHome, 'icons', 'hicolor', ICON_SIZE, 'apps');
+const iconPath = path.join(iconDir, `${APP_ID}.png`);
+
+function buildDesktopEntry(appImagePath: string): string {
+  // Exec must be quoted: AppImages commonly live in paths containing spaces.
+  return [
+    '[Desktop Entry]',
+    'Type=Application',
+    'Name=BSV Desktop',
+    'Comment=BSV Desktop Wallet - Electron Edition',
+    `Exec="${appImagePath}" --no-sandbox %U`,
+    `Icon=${APP_ID}`,
+    `StartupWMClass=${APP_ID}`,
+    'Terminal=false',
+    'Categories=Finance;',
+    `X-AppImage-Version=${app.getVersion()}`,
+    ''
+  ].join('\n');
+}
+
+/**
+ * Installs a .desktop entry and icon into the user's XDG data dir so the
+ * window manager can resolve the app's icon. Idempotent: rewrites only when
+ * the content would change, so a moved or upgraded AppImage self-corrects.
+ *
+ * No-ops unless running from an AppImage. Failures are logged and swallowed —
+ * a missing icon must never block startup.
+ */
+export function integrateAppImageDesktopEntry(): void {
+  if (process.platform !== 'linux') {
+    return;
+  }
+
+  // Set by the AppImage runtime; absent for deb/rpm installs, which register
+  // their own desktop entry through the package manager.
+  const appImagePath = process.env.APPIMAGE;
+  if (!appImagePath || !fs.existsSync(appImagePath)) {
+    return;
+  }
+
+  try {
+    const desired = buildDesktopEntry(appImagePath);
+    const existing = fs.existsSync(desktopFilePath)
+      ? fs.readFileSync(desktopFilePath, 'utf8')
+      : null;
+
+    if (existing !== desired) {
+      fs.mkdirSync(path.dirname(desktopFilePath), { recursive: true });
+      fs.writeFileSync(desktopFilePath, desired, { mode: 0o644 });
+      console.log(`[linux] Installed desktop entry at ${desktopFilePath}`);
+    }
+
+    // The icon ships inside the asar; copy it out so the icon theme can find
+    // it by name. readFileSync reads through the asar transparently.
+    const sourceIcon = path.join(__dirname, '../build/icon.png');
+    if (fs.existsSync(sourceIcon)) {
+      const source = fs.readFileSync(sourceIcon);
+      const current = fs.existsSync(iconPath) ? fs.readFileSync(iconPath) : null;
+
+      if (!current || !current.equals(source)) {
+        fs.mkdirSync(iconDir, { recursive: true });
+        fs.writeFileSync(iconPath, source, { mode: 0o644 });
+        console.log(`[linux] Installed icon at ${iconPath}`);
+      }
+    } else {
+      console.warn(`[linux] Icon not found at ${sourceIcon}; window icon may fall back`);
+    }
+  } catch (error) {
+    console.error('[linux] Desktop integration failed:', error);
+  }
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -6,6 +6,7 @@ import fs from 'fs';
 import { startHttpServer } from './httpServer.js';
 import { buildApplicationMenu } from './appMenu.js';
 import { applyPersistedProxySettings, registerNetworkIpc } from './networkSettings.js';
+import { integrateAppImageDesktopEntry } from './linuxDesktopIntegration.js';
 
 const require = createRequire(import.meta.url);
 
@@ -717,6 +718,11 @@ app.whenReady().then(async () => {
   } catch (error) {
     console.error('[Startup] Failed to apply persisted proxy settings, continuing startup without them:', error);
   }
+
+  // Must run before the window opens: the compositor resolves the icon when
+  // the toplevel is mapped, so a late-installed desktop entry is not picked up
+  // until the next launch.
+  integrateAppImageDesktopEntry();
 
   buildApplicationMenu({ getMainWindow: () => mainWindow });
   createWindow();

--- a/package.json
+++ b/package.json
@@ -99,7 +99,8 @@
     "files": [
       "dist/**/*",
       "dist-electron/**/*",
-      "package.json"
+      "package.json",
+      "build/icon.png"
     ],
     "asarUnpack": [
       "node_modules/better-sqlite3/**"
@@ -167,7 +168,10 @@
         "rpm"
       ],
       "category": "Finance",
-      "icon": "build/icon.png"
+      "icon": "build/icons",
+      "desktop": {
+        "StartupWMClass": "bsv-desktop-electron"
+      }
     }
   }
 }


### PR DESCRIPTION
## Problem

On Ubuntu the app shows a generic cog instead of its own icon. Three independent causes, all Linux-specific — fixing any one alone is not enough.

**1. The icon is never packaged.** `build.files` is `["dist/**/*", "dist-electron/**/*", "package.json"]`. Reading the asar header of a released 2.8.0 AppImage confirms the top-level entries are exactly `node_modules`, `dist-electron`, `dist`, `package.json` — no `build/`. So `getIconPath()` returns `../build/icon.png`, a path that does not exist at runtime. Electron silently ignores an unreadable icon, and `xprop` on the live window shows `_NET_WM_ICON: not found`.

macOS and Windows are unaffected because they read the icon from the `.app` bundle and the exe resource respectively, never from this path — which is why this only ever showed up on Linux.

**2. `StartupWMClass` cannot match.** electron-builder generated `StartupWMClass=BSV-Desktop` from `productName`, but the executable name comes from the package.json `name` field, `bsv-desktop-electron`. Verified against the running window:

```
WM_CLASS(STRING) = "bsv-desktop-electron", "bsv-desktop-electron"
```

**3. An AppImage installs no desktop entry at all.** Wayland has no protocol for a client to set its own window icon, so the compositor resolves it *purely* by matching the toplevel's `app_id` against installed `.desktop` files. Nothing had ever installed one — `~/.local/share/applications` and `/usr/share/applications` both had no BSV entry — so GNOME had nothing to look up.

## Changes

- Ship `build/icon.png` inside the asar so the `BrowserWindow` icon resolves, fixing `_NET_WM_ICON` under X11/XWayland.
- Point `linux.icon` at `build/icons/` rather than the single 1024×1024 PNG, so all sizes 16–1024 get packaged. The directory already exists with electron-builder's expected `NxN.png` naming; the released AppImage was shipping only the one 1024px file.
- Set `linux.desktop.StartupWMClass` to `bsv-desktop-electron` to match the real window class.
- Add `electron/linuxDesktopIntegration.ts`: when running from an AppImage (`$APPIMAGE` set), install a matching `.desktop` entry and icon under `XDG_DATA_HOME`. Idempotent — content-compared, so a moved or upgraded AppImage self-corrects. No-ops for deb/rpm, which register their own entry through the package manager. Runs before the window opens, since the compositor resolves the icon at map time.

## Verification

> [!WARNING]
> **Not compiled.** No Node toolchain on the test machine, so no `tsc --noEmit` and no packaged build. Please confirm CI is green before taking this out of draft.

The *mechanism* was verified end-to-end on Ubuntu 26.04 / GNOME / Wayland by hand-installing exactly what `linuxDesktopIntegration.ts` writes, then querying the same lookup path GNOME Shell uses:

```
desktop entry found: True
  name: BSV Desktop
  icon: bsv-desktop-electron
  StartupWMClass: bsv-desktop-electron
  icon resolves to: ~/.local/share/icons/hicolor/512x512/apps/bsv-desktop-electron.png
```

`desktop-file-validate` passes. Diagnosis of causes 1 and 2 is direct evidence — asar header dump and `xprop` against a released 2.8.0 AppImage.

Not verified: the rendered icon itself. GNOME blocks programmatic screenshots (`org.gnome.Shell.Screenshot` → `AccessDenied`), so visual confirmation in the dash and alt-tab still needs a human, ideally against a real build rather than the hand-installed entry.

## Note

`desktop-file-validate` hints that `Categories=Finance;` contains no registered main category, so the app may land in a catch-all menu section. `Office;Finance;` would fix it. Left alone here — it comes from `linux.category` and affects deb/rpm menu placement on every distro, so it seemed worth keeping separate from an icon fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)