### PR TITLE
Stop false macOS cert-trust warning after install

### DIFF
--- a/electron/sslCert.ts
+++ b/electron/sslCert.ts
@@ -319,15 +319,30 @@ async function isCertAcceptedByClients(): Promise<boolean | null> {
     });
 
     request.on('error', (error: Error & { code?: string }) => {
-      const code = error.code ?? '';
-      // Connection-level failures mean the server is not reachable yet, which
-      // says nothing about trust. Certificate failures are a real answer.
-      if (code === 'ECONNREFUSED' || code === 'ECONNRESET' || code === 'ENOTFOUND') {
-        console.log(`Certificate probe inconclusive (${code}): bridge not reachable`);
+      // Electron's net module reports Chromium errors as `net::ERR_…` in
+      // `error.message` and often leaves `error.code` unset. Classify from
+      // both so a connection failure cannot be mistaken for a trust failure.
+      const token = `${error.code ?? ''} ${error.message ?? ''}`;
+      const inconclusive = [
+        'ECONNREFUSED',
+        'ECONNRESET',
+        'ENOTFOUND',
+        'ETIMEDOUT',
+        'ERR_CONNECTION_REFUSED',
+        'ERR_CONNECTION_RESET',
+        'ERR_NAME_NOT_RESOLVED',
+        'ERR_ADDRESS_UNREACHABLE',
+        'ERR_CONNECTION_TIMED_OUT',
+        'ERR_EMPTY_RESPONSE',
+        'ERR_ABORTED'
+      ];
+      if (inconclusive.some((marker) => token.includes(marker))) {
+        const label = error.code || error.message || 'unreachable';
+        console.log(`Certificate probe inconclusive (${label}): bridge not reachable`);
         finish(null);
         return;
       }
-      console.log(`Certificate probe rejected the endpoint: ${code || error.message}`);
+      console.log(`Certificate probe rejected the endpoint: ${error.code || error.message}`);
       finish(false);
     });
 
@@ -346,11 +361,12 @@ async function isCertAcceptedByClients(): Promise<boolean | null> {
 async function isCertTrusted(certPath: string): Promise<boolean> {
   try {
     if (process.platform === 'darwin') {
-      // macOS: Check if cert is in user keychain (CN is "localhost", not org name)
-      const loginKeychain = path.join(os.homedir(), 'Library/Keychains/login.keychain-db');
-      await execFileAsync('security', ['find-certificate', '-c', 'localhost', '-p', loginKeychain]);
-      // Also verify it's actually trusted, not just present
-      await execFileAsync('security', ['verify-cert', '-c', certPath, '-p', 'ssl', '-s', 'localhost']);
+      // verify-cert consults the default keychain search list (login + System)
+      // and both trust domains. The cert may have been installed into the
+      // System keychain via the admin fallback, so a login-keychain
+      // find-certificate is not a valid gate — it would report a successfully
+      // installed System cert as untrusted.
+      await execFileAsync('security', ['verify-cert', '-c', certPath, '-p', 'ssl', '-n', 'localhost']);
       return true;
     } else if (process.platform === 'win32') {
       // Windows: look the certificate up in the user's trusted root store by its
@@ -624,12 +640,14 @@ Certificate location: ${certPath}`;
 
   try {
     if (platform === 'darwin') {
-      // macOS: add-trusted-cert with -d flag adds to admin trust settings (needs auth prompt)
-      // First try without sudo — works if user has keychain access
+      // User trust domain first. `-d` writes admin trust settings and needs an
+      // authorization prompt that a child process cannot present, so pairing it
+      // with the login keychain usually fails and forced the System-keychain
+      // fallback even for unprivileged users.
       const loginKeychain = path.join(os.homedir(), 'Library/Keychains/login.keychain-db');
       try {
         await execFileAsync('security', [
-          'add-trusted-cert', '-d', '-r', 'trustRoot', '-k', loginKeychain, certPath
+          'add-trusted-cert', '-r', 'trustRoot', '-p', 'ssl', '-k', loginKeychain, certPath
         ]);
       } catch (firstErr) {
         console.log('Direct trust failed, trying with osascript admin prompt...');
@@ -637,7 +655,7 @@ Certificate location: ${certPath}`;
         // `security` with administrator privileges; build it from a JSON-quoted
         // path so shell metacharacters in certPath cannot break out of the string.
         const innerCmd =
-          'security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain '
+          'security add-trusted-cert -d -r trustRoot -p ssl -k /Library/Keychains/System.keychain '
           + JSON.stringify(certPath);
         await execFileAsync('osascript', [
           '-e', `do shell script ${JSON.stringify(innerCmd)} with administrator privileges`
@@ -761,14 +779,31 @@ export async function ensureCertTrusted(
   // Verify against a real client again, not just the store. On managed Windows
   // machines the two can disagree: the certificate is genuinely in the store
   // and genuinely not honoured.
+  //
+  // On macOS they also disagree, but the other way around. Chromium loads
+  // keychain trust at process start and does not pick up an add-trusted-cert
+  // that just ran in this same process. The probe then returns
+  // ERR_CERT_AUTHORITY_INVALID even though `security verify-cert` succeeds
+  // and a fresh process accepts the endpoint. Treat a verified store as
+  // success everywhere except Windows, where that combination is the policy
+  // case the warning exists for.
   const nowAccepted = await isCertAcceptedByClients();
   if (nowAccepted === true) {
     console.log('Certificate successfully installed and verified');
     return;
   }
 
-  if (nowAccepted === null && await isCertTrusted(certPath)) {
-    console.log('Certificate installed; endpoint not reachable to confirm end to end');
+  if (await isCertTrusted(certPath)) {
+    if (nowAccepted === false && process.platform === 'win32') {
+      console.log('Certificate install reported success but verification failed');
+      await explainVerificationFailure(certPath, parentWindow);
+      return;
+    }
+    console.log(
+      nowAccepted === null
+        ? 'Certificate installed; endpoint not reachable to confirm end to end'
+        : 'Certificate installed; network stack will honour it after restart'
+    );
     return;
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bsv-desktop-electron",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bsv-desktop-electron",
-      "version": "2.8.1",
+      "version": "2.8.2",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bsv-desktop-electron",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "description": "BSV Desktop Wallet - Electron Edition",
   "main": "dist-electron/main.js",
   "type": "module",

--- a/test/sslCertTrustProbe.test.ts
+++ b/test/sslCertTrustProbe.test.ts
@@ -12,7 +12,7 @@
  * answers the question that actually matters.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { EventEmitter } from 'events'
 import os from 'os'
 import path from 'path'
@@ -22,7 +22,7 @@ import forge from 'node-forge'
 const showMessageBox = vi.fn(async () => ({ response: 1, checkboxChecked: false }))
 
 /** Controls what the fake network stack does with the probe request. */
-let probeBehaviour: 'accept' | 'reject-cert' | 'refused' = 'accept'
+let probeBehaviour: 'accept' | 'reject-cert' | 'reject-cert-chromium' | 'refused' | 'refused-chromium' = 'accept'
 
 class FakeClientRequest extends EventEmitter {
   end() {
@@ -36,6 +36,12 @@ class FakeClientRequest extends EventEmitter {
         const error = new Error('certificate verify failed') as Error & { code?: string }
         error.code = 'ERR_CERT_AUTHORITY_INVALID'
         this.emit('error', error)
+      } else if (probeBehaviour === 'reject-cert-chromium') {
+        // Real Electron net errors put the Chromium code in the message and
+        // leave error.code unset. That is the shape we see on macOS.
+        this.emit('error', new Error('net::ERR_CERT_AUTHORITY_INVALID'))
+      } else if (probeBehaviour === 'refused-chromium') {
+        this.emit('error', new Error('net::ERR_CONNECTION_REFUSED'))
       } else {
         const error = new Error('connection refused') as Error & { code?: string }
         error.code = 'ECONNREFUSED'
@@ -56,16 +62,26 @@ vi.mock('electron', () => ({
 }))
 
 /** Controls what external commands do. */
-let execBehaviour: 'fail-all' | 'install-succeeds' = 'fail-all'
+let execBehaviour: 'fail-all' | 'install-succeeds' | 'darwin-install-verifies' | 'already-trusted-verify-cert' = 'fail-all'
 
-// Store lookups report "not trusted", so any decision not to prompt must have
-// come from the probe rather than from the store. Uses promisify.custom because
-// sslCert wraps execFile with util.promisify and destructures { stdout }.
+/** Captures `security add-trusted-cert` argv so tests can assert the flags. */
+const securityAddArgv: string[][] = []
+
+/** After a mocked macOS install, verify-cert starts succeeding. */
+let darwinCertInKeychain = false
+
+// Store lookups report "not trusted" unless a behaviour below says otherwise.
+// Uses promisify.custom because sslCert wraps execFile with util.promisify
+// and destructures { stdout }.
 vi.mock('child_process', () => {
   const execFile = (() => { /* callback form unused */ }) as unknown as Record<symbol, unknown>
 
   execFile[Symbol.for('nodejs.util.promisify.custom')] = async (cmd: string, args: string[] = []) => {
     const argv = args.join(' ')
+
+    if (cmd === 'security' && argv.includes('add-trusted-cert')) {
+      securityAddArgv.push([...args])
+    }
 
     if (execBehaviour === 'install-succeeds') {
       // The install itself works — this is the managed-Windows case where the
@@ -73,6 +89,34 @@ vi.mock('child_process', () => {
       if (argv.includes('-addstore')) return { stdout: 'CertUtil: -addstore command completed successfully.', stderr: '' }
       // Group policy restricting user root CAs is present.
       if (cmd === 'reg') return { stdout: '    Flags    REG_DWORD    0x1', stderr: '' }
+    }
+
+    if (execBehaviour === 'darwin-install-verifies') {
+      if (cmd === 'security' && argv.includes('add-trusted-cert')) {
+        darwinCertInKeychain = true
+        return { stdout: '', stderr: '' }
+      }
+      if (cmd === 'security' && argv.includes('verify-cert')) {
+        if (darwinCertInKeychain) {
+          return { stdout: '...certificate verification successful.', stderr: '' }
+        }
+        const error = new Error('CSSMERR_TP_NOT_TRUSTED') as Error & { stdout: string }
+        error.stdout = 'Cert Verify Result: CSSMERR_TP_NOT_TRUSTED'
+        throw error
+      }
+      if (cmd === 'security' && argv.includes('find-certificate')) {
+        // Install landed in the System keychain; the login keychain lookup
+        // that used to gate the whole macOS check must not decide this.
+        const error = new Error('The specified item could not be found in the keychain.') as Error & { stdout: string }
+        error.stdout = ''
+        throw error
+      }
+    }
+
+    if (execBehaviour === 'already-trusted-verify-cert') {
+      if (cmd === 'security' && argv.includes('verify-cert')) {
+        return { stdout: '...certificate verification successful.', stderr: '' }
+      }
     }
 
     const error = new Error('CertUtil: -verifystore command FAILED: 0x80090011') as Error & { stdout: string }
@@ -112,13 +156,26 @@ function writeTempCert(): string {
 let sslCert: typeof import('../electron/sslCert')
 let certPath: string
 
+const originalPlatform = process.platform
+
+function stubPlatform(platform: NodeJS.Platform) {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true })
+}
+
 describe('certificate trust verification', () => {
   beforeEach(async () => {
     showMessageBox.mockClear()
     request.mockClear()
+    securityAddArgv.length = 0
+    darwinCertInKeychain = false
     execBehaviour = 'fail-all'
+    stubPlatform(originalPlatform)
     sslCert = await import('../electron/sslCert')
     certPath = writeTempCert()
+  })
+
+  afterEach(() => {
+    stubPlatform(originalPlatform)
   })
 
   it('does not prompt when a real client already accepts the endpoint', async () => {
@@ -152,6 +209,7 @@ describe('certificate trust verification', () => {
   it('explains the failure when the cert installs but is still not honoured', async () => {
     // The managed-Windows case: policy forbids user-installed root CAs, so the
     // install genuinely succeeds and the certificate is genuinely ignored.
+    stubPlatform('win32')
     probeBehaviour = 'reject-cert'
     execBehaviour = 'install-succeeds'
     showMessageBox.mockResolvedValueOnce({ response: 0, checkboxChecked: false }) // "Trust Certificate"
@@ -163,6 +221,65 @@ describe('certificate trust verification', () => {
     const warning = showMessageBox.mock.calls[1][1] as unknown as Electron.MessageBoxOptions
     expect(warning.title).toBe('Certificate Not Trusted')
     expect(warning.detail).toContain('policy')
+  })
+
+  it('does not warn on macOS when install succeeds but this process still rejects TLS', async () => {
+    // Chromium caches keychain trust at process start. After add-trusted-cert
+    // the store verifies the cert and a fresh process accepts it, but the
+    // in-process probe still returns ERR_CERT_AUTHORITY_INVALID. That is not
+    // a device-policy failure and must not scare the user.
+    stubPlatform('darwin')
+    probeBehaviour = 'reject-cert-chromium'
+    execBehaviour = 'darwin-install-verifies'
+    showMessageBox.mockResolvedValueOnce({ response: 0, checkboxChecked: false })
+
+    await sslCert.ensureCertTrusted(certPath, new FakeWindow() as never)
+
+    expect(showMessageBox).toHaveBeenCalledTimes(1)
+    const prompt = showMessageBox.mock.calls[0][1] as unknown as Electron.MessageBoxOptions
+    expect(prompt.title).toBe('SSL Certificate Trust')
+  })
+
+  it('trusts the macOS keychain even when the cert is not in the login keychain', async () => {
+    // The osascript fallback installs into the System keychain. Looking the
+    // cert up only in login.keychain-db used to report "untrusted" and trip
+    // the warning even after a successful admin install.
+    stubPlatform('darwin')
+    probeBehaviour = 'reject-cert-chromium'
+    execBehaviour = 'darwin-install-verifies'
+    showMessageBox.mockResolvedValueOnce({ response: 0, checkboxChecked: false })
+
+    await sslCert.ensureCertTrusted(certPath, new FakeWindow() as never)
+
+    expect(showMessageBox.mock.calls.map(([, options]) => (
+      options as Electron.MessageBoxOptions
+    ).title)).not.toContain('Certificate Not Trusted')
+  })
+
+  it('adds the macOS cert to the user trust domain before asking for admin', async () => {
+    stubPlatform('darwin')
+    probeBehaviour = 'reject-cert-chromium'
+    execBehaviour = 'darwin-install-verifies'
+    showMessageBox.mockResolvedValueOnce({ response: 0, checkboxChecked: false })
+
+    await sslCert.ensureCertTrusted(certPath, new FakeWindow() as never)
+
+    expect(securityAddArgv.length).toBeGreaterThan(0)
+    expect(securityAddArgv[0]).toContain('add-trusted-cert')
+    expect(securityAddArgv[0]).toContain('trustRoot')
+    expect(securityAddArgv[0]).not.toContain('-d')
+  })
+
+  it('treats a Chromium connection-refused (no error.code) as inconclusive', async () => {
+    // Electron's net module reports net::ERR_CONNECTION_REFUSED in the
+    // message and leaves code undefined. That is not a trust answer.
+    stubPlatform('darwin')
+    probeBehaviour = 'refused-chromium'
+    execBehaviour = 'already-trusted-verify-cert'
+
+    await sslCert.ensureCertTrusted(certPath, new FakeWindow() as never)
+
+    expect(showMessageBox).not.toHaveBeenCalled()
   })
 
   it('falls back to the store when the bridge is not reachable', async () => {


### PR DESCRIPTION
## Description of Changes

Fixes the startup warning on macOS:

> BSV Desktop could not establish a trusted local connection
> The certificate was installed, but the secure local connection is still being rejected...

That dialog is the post-install probe added for managed Windows. On macOS it is a false positive.

Chromium loads keychain trust at process start. After `add-trusted-cert` succeeds, `security verify-cert` accepts the cert and a **new** Electron process accepts `https://127.0.0.1`, but the in-process `net.request` probe still returns `net::ERR_CERT_AUTHORITY_INVALID`. The app treated that as "installed but ignored by policy" and scared the user.

Also:

- Install into the **user** trust domain first (`add-trusted-cert` without `-d`). `-d` on the login keychain needs an auth prompt a child process cannot present, so the first attempt usually failed and fell through to the System keychain.
- Trust detection on macOS now uses `security verify-cert` against the default search list. Requiring `find-certificate` in `login.keychain-db` reported a successful System-keychain install as untrusted.
- Classify Electron probe errors from `error.message` (`net::ERR_…`) as well as `error.code`. Real Chromium errors often leave `code` unset, so `ERR_CONNECTION_REFUSED` was treated as a certificate rejection.

Windows behaviour is unchanged: store-present + live client still rejecting still shows the policy warning.

## Linked Issues / Tickets

Closes #75

## Changes

- `electron/sslCert.ts`: macOS install flags, verify-cert-only store check, post-install probe vs store, Chromium error classification
- `test/sslCertTrustProbe.test.ts`: darwin false-warning, System-keychain-only install, user-domain flags, `net::ERR_CONNECTION_REFUSED` without `error.code`; stub `win32` on the existing policy test so it runs on macOS/Linux

## Testing Procedure

Reproduced on macOS 26.6.1 with Electron 41:

1. Generated a `CA:FALSE` localhost cert, added it with `security add-trusted-cert -r trustRoot -p ssl` to the login keychain.
2. Same Electron process: probe still `ERR_CERT_AUTHORITY_INVALID`; `security verify-cert` succeeded.
3. Fresh Electron process: probe accepted both the leaf and a `CA:TRUE` variant.
4. Confirmed Electron's error object has **no** `code` — only `message: "net::ERR_CERT_AUTHORITY_INVALID"`.

- [x] I have added new unit tests
- [x] All tests pass locally (`vitest` sslCert* : 16 passed; `tsc -p tsconfig.electron.json --noEmit` clean)
- [x] I have tested the trust/probe behaviour manually with Electron against a real keychain

## Test plan

- [ ] On macOS: launch, click **Trust Certificate**, confirm the policy warning does **not** appear
- [ ] Quit and relaunch: no cert prompt, no warning
- [ ] External browser against `https://127.0.0.1:2121/manifest.json` after a restart accepts the cert
- [ ] Windows managed-policy case still shows the existing warning (unchanged)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
- [ ] I have run `npm run doc` and `npm run lint` one final time before requesting a review
- [ ] I have fixed all linter errors to ensure these changes are compliant with `ts-standard`
- [ ] I have run `npm version patch` so that my changes will trigger a new version to be released when they are merged