### PR TITLE
Typeset the update dialogs

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "package:win": "electron-builder --win",
     "package:linux": "electron-builder --linux",
     "lint:ci": "echo 'No linting'",
-    "test": "vitest run --config vitest.config.electron.ts test/translations.test.ts test/appIconFallback.test.ts",
+    "test": "vitest run --config vitest.config.electron.ts test/translations.test.ts test/appIconFallback.test.ts test/formatReleaseNotes.test.ts",
     "test:stas": "vitest run --config vitest.config.electron.ts test/stas",
     "test:tokens": "vitest run --config vitest.config.electron.ts test/tokens",
     "test:stas:db": "npm rebuild better-sqlite3 && vitest run --config vitest.config.electron.ts test/stas; npm run rebuild:electron",

--- a/src/lib/components/UpdateNotification.tsx
+++ b/src/lib/components/UpdateNotification.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Dialog,
@@ -8,15 +8,17 @@ import {
   Button,
   Typography,
   LinearProgress,
-  Box
+  Box,
+  Stack
 } from '@mui/material';
+import { alpha, useTheme } from '@mui/material/styles';
 import { toast } from 'react-toastify';
-import DOMPurify from 'dompurify';
+import { releaseNotesToHtml } from '../utils/formatReleaseNotes';
 
 interface UpdateInfo {
   version: string;
   releaseDate?: string;
-  releaseNotes?: string;
+  releaseNotes?: string | Array<{ version: string; note: string | null }> | null;
 }
 
 interface DownloadProgress {
@@ -31,16 +33,27 @@ interface UpdateNotificationProps {
   onDismissManualUpdate?: () => void;
 }
 
+const dialogPaperSx = {
+  width: '100%',
+  maxWidth: 520
+} as const;
+
 export const UpdateNotification: React.FC<UpdateNotificationProps> = ({
   manualUpdateInfo,
   onDismissManualUpdate
 }) => {
   const { t } = useTranslation();
+  const theme = useTheme();
   const [updateAvailable, setUpdateAvailable] = useState(false);
   const [updateInfo, setUpdateInfo] = useState<UpdateInfo | null>(null);
   const [downloading, setDownloading] = useState(false);
   const [downloadProgress, setDownloadProgress] = useState<DownloadProgress | null>(null);
   const [updateReady, setUpdateReady] = useState(false);
+
+  const notesHtml = useMemo(
+    () => releaseNotesToHtml(updateInfo?.releaseNotes),
+    [updateInfo?.releaseNotes]
+  );
 
   // Handle manual update info from Settings
   useEffect(() => {
@@ -159,58 +172,160 @@ export const UpdateNotification: React.FC<UpdateNotificationProps> = ({
     return Math.round(bytes / Math.pow(k, i) * 100) / 100 + ' ' + sizes[i];
   };
 
+  const linkColor = theme.palette.mode === 'light' ? '#1B365D' : '#8BB4E0';
+  const linkHover = theme.palette.mode === 'light' ? '#2C5282' : '#B7D2F3';
+  const notesInk = theme.palette.mode === 'light' ? '#3D4654' : 'rgba(255,255,255,0.82)';
+  const notesSurface = theme.palette.mode === 'light'
+    ? 'rgba(27,54,93,0.04)'
+    : 'rgba(255,255,255,0.045)';
+  const notesBorder = theme.palette.mode === 'light'
+    ? 'rgba(27,54,93,0.10)'
+    : 'rgba(255,255,255,0.08)';
+
+  const versionChip = updateInfo?.version ? (
+    <Box
+      component="span"
+      sx={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        px: 1.25,
+        py: 0.35,
+        borderRadius: '999px',
+        fontSize: 12,
+        fontWeight: 600,
+        letterSpacing: '0.01em',
+        fontVariantNumeric: 'tabular-nums',
+        color: '#FFFFFF',
+        backgroundColor: 'rgba(255,255,255,0.16)',
+        border: '1px solid rgba(255,255,255,0.18)'
+      }}
+    >
+      {updateInfo.version}
+    </Box>
+  ) : null;
+
   return (
     <>
       {/* Update Available Dialog */}
-      <Dialog open={updateAvailable} onClose={handleDismiss}>
-        <DialogTitle>{t('update_notification_available_title')}</DialogTitle>
-        <DialogContent>
-          <Typography variant="body1" gutterBottom>
+      <Dialog
+        open={updateAvailable}
+        onClose={handleDismiss}
+        fullWidth
+        PaperProps={{ sx: dialogPaperSx }}
+      >
+        <DialogTitle component="div" sx={{ px: 3, py: 2 }}>
+          <Stack direction="row" alignItems="center" justifyContent="space-between" gap={2}>
+            <Typography component="h2" variant="h6" fontWeight={700} sx={{ color: 'inherit' }}>
+              {t('update_notification_available_title')}
+            </Typography>
+            {versionChip}
+          </Stack>
+        </DialogTitle>
+        <DialogContent sx={{ p: 0 }}>
+          <Box sx={{ px: 3, pt: 3, pb: 1.5 }}>
+          <Typography variant="body1" sx={{ mb: 2.5, lineHeight: 1.55 }}>
             {t('update_notification_available_body')}
           </Typography>
-          {updateInfo && (
-            <>
-              <Typography variant="body2" color="textSecondary" gutterBottom>
-                {t('update_notification_version_label')}: {updateInfo.version}
+          {notesHtml ? (
+            <Box sx={{ mb: 2.5 }}>
+              <Typography
+                variant="overline"
+                sx={{
+                  display: 'block',
+                  mb: 1,
+                  color: 'text.secondary',
+                  letterSpacing: '0.08em',
+                  fontWeight: 600
+                }}
+              >
+                {t('update_notification_release_notes_label')}
               </Typography>
-              {updateInfo.releaseNotes && (
-                <Box mt={2}>
-                  <Typography variant="body2" color="textSecondary">
-                    {t('update_notification_release_notes_label')}:
-                  </Typography>
-                  <Box
-                    sx={{
-                      marginTop: 1,
-                      padding: 1,
-                      backgroundColor: 'background.paper',
-                      borderRadius: 1,
-                      border: '1px solid',
-                      borderColor: 'divider'
-                    }}
-                  >
-                    <div
-                      dangerouslySetInnerHTML={{
-                        __html: DOMPurify.sanitize(
-                          updateInfo.releaseNotes || t('update_notification_no_release_notes'),
-                          { USE_PROFILES: { html: true } }
-                        )
-                      }}
-                      style={{
-                        fontSize: '0.875rem',
-                        lineHeight: 1.5,
-                        color: 'text.secondary'
-                      }}
-                    />
-                  </Box>
-                </Box>
-              )}
-            </>
-          )}
-          <Typography variant="body2" color="textSecondary" style={{ marginTop: 16 }}>
+              <Box
+                className="update-release-notes"
+                sx={{
+                  px: 2.5,
+                  py: 2,
+                  maxHeight: 300,
+                  overflow: 'auto',
+                  borderRadius: '8px',
+                  backgroundColor: notesSurface,
+                  border: '1px solid',
+                  borderColor: notesBorder,
+                  color: notesInk,
+                  fontSize: '0.9rem',
+                  lineHeight: 1.6,
+                  '& > :first-of-type': { mt: 0 },
+                  '& > :last-child': { mb: 0 },
+                  '& h1, & h2, & h3': {
+                    color: theme.palette.mode === 'light' ? '#1B365D' : '#FFFFFF',
+                    fontWeight: 600,
+                    letterSpacing: '-0.015em',
+                    textWrap: 'balance',
+                    mt: 2,
+                    mb: 1
+                  },
+                  '& h1': { fontSize: '1.15rem' },
+                  '& h2': { fontSize: '1.02rem' },
+                  '& h3': { fontSize: '0.95rem' },
+                  '& p': { my: 1.25 },
+                  '& ul, & ol': { my: 1.25, pl: 2.5 },
+                  '& li': { mb: 0.75, pl: 0.25 },
+                  '& li::marker': { color: alpha(linkColor, 0.7) },
+                  '& a': {
+                    color: `${linkColor} !important`,
+                    textDecoration: 'underline',
+                    textDecorationColor: alpha(linkColor, 0.35),
+                    textUnderlineOffset: '3px',
+                    fontWeight: 500
+                  },
+                  '& a:hover': {
+                    color: `${linkHover} !important`,
+                    textDecorationColor: linkHover
+                  },
+                  '& a:visited': {
+                    color: `${linkColor} !important`
+                  },
+                  '& code': {
+                    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+                    fontSize: '0.82em',
+                    px: 0.6,
+                    py: 0.15,
+                    borderRadius: '4px',
+                    backgroundColor: theme.palette.mode === 'light'
+                      ? 'rgba(27,54,93,0.08)'
+                      : 'rgba(255,255,255,0.08)'
+                  },
+                  '& pre': {
+                    my: 1.5,
+                    px: 1.5,
+                    py: 1.25,
+                    overflow: 'auto',
+                    borderRadius: '6px',
+                    backgroundColor: theme.palette.mode === 'light'
+                      ? 'rgba(27,54,93,0.06)'
+                      : 'rgba(0,0,0,0.28)'
+                  },
+                  '& pre code': {
+                    px: 0,
+                    backgroundColor: 'transparent'
+                  },
+                  '& hr': {
+                    border: 0,
+                    borderTop: `1px solid ${notesBorder}`,
+                    my: 2
+                  },
+                  '& strong': { fontWeight: 600, color: theme.palette.mode === 'light' ? '#1B365D' : '#FFFFFF' }
+                }}
+                dangerouslySetInnerHTML={{ __html: notesHtml }}
+              />
+            </Box>
+          ) : null}
+          <Typography variant="body2" color="text.secondary" sx={{ lineHeight: 1.5 }}>
             {t('update_notification_data_preserved')}
           </Typography>
+          </Box>
         </DialogContent>
-        <DialogActions>
+        <DialogActions sx={{ px: 3, py: 2, gap: 1 }}>
           <Button onClick={handleDismiss} color="primary">
             {t('update_notification_later')}
           </Button>
@@ -221,40 +336,87 @@ export const UpdateNotification: React.FC<UpdateNotificationProps> = ({
       </Dialog>
 
       {/* Downloading Dialog */}
-      <Dialog open={downloading} disableEscapeKeyDown>
-        <DialogTitle>{t('update_notification_downloading_title')}</DialogTitle>
-        <DialogContent>
-          <Typography variant="body2" gutterBottom>
+      <Dialog open={downloading} disableEscapeKeyDown fullWidth PaperProps={{ sx: dialogPaperSx }}>
+        <DialogTitle component="div" sx={{ px: 3, py: 2 }}>
+          <Stack direction="row" alignItems="center" justifyContent="space-between" gap={2}>
+            <Typography component="h2" variant="h6" fontWeight={700} sx={{ color: 'inherit' }}>
+              {t('update_notification_downloading_title')}
+            </Typography>
+            {versionChip}
+          </Stack>
+        </DialogTitle>
+        <DialogContent sx={{ p: 0 }}>
+          <Box sx={{ px: 3, pt: 3, pb: 3 }}>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 3, lineHeight: 1.55 }}>
             {t('update_notification_downloading_body', { version: updateInfo?.version })}
           </Typography>
           {downloadProgress && (
-            <Box mt={2}>
-              <LinearProgress variant="determinate" value={downloadProgress.percent} />
-              <Typography variant="body2" color="textSecondary" align="center" style={{ marginTop: 8 }}>
-                {downloadProgress.percent.toFixed(1)}% - {formatBytes(downloadProgress.transferred)} / {formatBytes(downloadProgress.total)}
+            <Box>
+              <Typography
+                sx={{
+                  fontSize: 32,
+                  fontWeight: 600,
+                  letterSpacing: '-0.03em',
+                  fontVariantNumeric: 'tabular-nums',
+                  lineHeight: 1,
+                  mb: 2,
+                  color: theme.palette.mode === 'light' ? '#1B365D' : '#FFFFFF'
+                }}
+              >
+                {downloadProgress.percent.toFixed(0)}%
               </Typography>
-              {downloadProgress.bytesPerSecond > 0 && (
-                <Typography variant="body2" color="textSecondary" align="center">
-                  {formatBytes(downloadProgress.bytesPerSecond)}/s
-                </Typography>
-              )}
+              <LinearProgress
+                variant="determinate"
+                value={downloadProgress.percent}
+                sx={{
+                  height: 6,
+                  borderRadius: 999,
+                  backgroundColor: notesSurface,
+                  '& .MuiLinearProgress-bar': { borderRadius: 999 }
+                }}
+              />
+              <Typography
+                variant="body2"
+                color="text.secondary"
+                sx={{ mt: 1.5, fontVariantNumeric: 'tabular-nums' }}
+              >
+                {formatBytes(downloadProgress.transferred)} / {formatBytes(downloadProgress.total)}
+                {downloadProgress.bytesPerSecond > 0
+                  ? ` · ${formatBytes(downloadProgress.bytesPerSecond)}/s`
+                  : ''}
+              </Typography>
             </Box>
           )}
+          </Box>
         </DialogContent>
       </Dialog>
 
       {/* Update Ready Dialog */}
-      <Dialog open={updateReady} onClose={handleDismissReady}>
-        <DialogTitle>{t('update_notification_ready_title')}</DialogTitle>
-        <DialogContent>
-          <Typography variant="body1" gutterBottom>
+      <Dialog
+        open={updateReady}
+        onClose={handleDismissReady}
+        fullWidth
+        PaperProps={{ sx: dialogPaperSx }}
+      >
+        <DialogTitle component="div" sx={{ px: 3, py: 2 }}>
+          <Stack direction="row" alignItems="center" justifyContent="space-between" gap={2}>
+            <Typography component="h2" variant="h6" fontWeight={700} sx={{ color: 'inherit' }}>
+              {t('update_notification_ready_title')}
+            </Typography>
+            {versionChip}
+          </Stack>
+        </DialogTitle>
+        <DialogContent sx={{ p: 0 }}>
+          <Box sx={{ px: 3, pt: 3, pb: 1.5 }}>
+          <Typography variant="body1" sx={{ mb: 1.5, lineHeight: 1.55 }}>
             {t('update_notification_ready_body')}
           </Typography>
-          <Typography variant="body2" color="textSecondary">
+          <Typography variant="body2" color="text.secondary" sx={{ lineHeight: 1.55 }}>
             {t('update_notification_ready_restart_note')}
           </Typography>
+          </Box>
         </DialogContent>
-        <DialogActions>
+        <DialogActions sx={{ px: 3, py: 2, gap: 1 }}>
           <Button onClick={handleDismissReady} color="primary">
             {t('update_notification_install_later')}
           </Button>

--- a/src/lib/utils/formatReleaseNotes.ts
+++ b/src/lib/utils/formatReleaseNotes.ts
@@ -1,0 +1,143 @@
+import DOMPurify from 'dompurify'
+
+/**
+ * Turns whatever electron-updater / GitHub handed us into sanitized HTML
+ * suitable for the update dialog.
+ *
+ * Release notes arrive as markdown, HTML, or an array of { version, note }.
+ * Dumping any of those straight into innerHTML is why the dialog looked
+ * unpadded and why links kept the browser's blue/purple defaults.
+ */
+
+export function normalizeReleaseNotes(raw: unknown): string {
+  if (raw == null) return ''
+
+  if (Array.isArray(raw)) {
+    return raw
+      .map((item) => {
+        if (typeof item === 'string') return item
+        if (item && typeof item === 'object' && typeof (item as { note?: unknown }).note === 'string') {
+          const { version, note } = item as { version?: string; note: string }
+          return version ? `## ${version}\n\n${note}` : note
+        }
+        return ''
+      })
+      .filter(Boolean)
+      .join('\n\n')
+  }
+
+  return String(raw)
+}
+
+function looksLikeHtml(text: string): boolean {
+  return /<\/?[a-z][\s\S]*>/i.test(text)
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+function markdownToHtml(markdown: string): string {
+  const lines = escapeHtml(markdown.replace(/\r\n/g, '\n')).split('\n')
+  const out: string[] = []
+  let i = 0
+
+  while (i < lines.length) {
+    const line = lines[i]
+    if (!line.trim()) {
+      i += 1
+      continue
+    }
+
+    if (/^---+$/.test(line.trim())) {
+      out.push('<hr />')
+      i += 1
+      continue
+    }
+
+    const heading = /^(#{1,3})\s+(.+)$/.exec(line)
+    if (heading) {
+      const level = heading[1].length
+      out.push(`<h${level}>${inline(heading[2])}</h${level}>`)
+      i += 1
+      continue
+    }
+
+    if (/^[*-]\s+/.test(line)) {
+      const items: string[] = []
+      while (i < lines.length && /^[*-]\s+/.test(lines[i])) {
+        items.push(`<li>${inline(lines[i].replace(/^[*-]\s+/, ''))}</li>`)
+        i += 1
+      }
+      out.push(`<ul>${items.join('')}</ul>`)
+      continue
+    }
+
+    if (/^\d+\.\s+/.test(line)) {
+      const items: string[] = []
+      while (i < lines.length && /^\d+\.\s+/.test(lines[i])) {
+        items.push(`<li>${inline(lines[i].replace(/^\d+\.\s+/, ''))}</li>`)
+        i += 1
+      }
+      out.push(`<ol>${items.join('')}</ol>`)
+      continue
+    }
+
+    const para: string[] = []
+    while (
+      i < lines.length
+      && lines[i].trim()
+      && !/^(#{1,3})\s+/.test(lines[i])
+      && !/^[*-]\s+/.test(lines[i])
+      && !/^\d+\.\s+/.test(lines[i])
+      && !/^---+$/.test(lines[i].trim())
+    ) {
+      para.push(inline(lines[i]))
+      i += 1
+    }
+    out.push(`<p>${para.join('<br />')}</p>`)
+  }
+
+  return out.join('')
+}
+
+function inline(text: string): string {
+  return text
+    .replace(/`([^`]+)`/g, '<code>$1</code>')
+    .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+    .replace(/\[([^\]]+)\]\((https?:[^)\s]+)\)/g, (
+      _match,
+      label: string,
+      href: string
+    ) => `<a href="${href}">${label}</a>`)
+    .replace(/(^|[^"'>=])(https?:\/\/[^\s<]+)/g, (
+      _match,
+      prefix: string,
+      href: string
+    ) => {
+      const cleaned = href.replace(/[.,;:)]+$/, '')
+      const trailing = href.slice(cleaned.length)
+      return `${prefix}<a href="${cleaned}">${cleaned}</a>${trailing}`
+    })
+}
+
+function addLinkTargets(html: string): string {
+  return html.replace(/<a\s+/gi, '<a target="_blank" rel="noopener noreferrer" ')
+}
+
+export function releaseNotesToHtml(raw: unknown): string {
+  const text = normalizeReleaseNotes(raw).trim()
+  if (!text) return ''
+
+  const html = looksLikeHtml(text) ? text : markdownToHtml(text)
+  const cleaned = typeof window === 'undefined'
+    ? html
+    : DOMPurify.sanitize(html, {
+      USE_PROFILES: { html: true },
+      ADD_ATTR: ['target', 'rel']
+    })
+  return addLinkTargets(cleaned)
+}

--- a/test/formatReleaseNotes.test.ts
+++ b/test/formatReleaseNotes.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeReleaseNotes, releaseNotesToHtml } from '../src/lib/utils/formatReleaseNotes'
+
+describe('normalizeReleaseNotes', () => {
+  it('joins electron-updater note arrays into markdown', () => {
+    expect(normalizeReleaseNotes([
+      { version: '2.8.2', note: 'Fix cert install' },
+      { version: '2.8.1', note: 'Linux icon' }
+    ])).toBe('## 2.8.2\n\nFix cert install\n\n## 2.8.1\n\nLinux icon')
+  })
+
+  it('returns an empty string for missing notes', () => {
+    expect(normalizeReleaseNotes(null)).toBe('')
+    expect(normalizeReleaseNotes(undefined)).toBe('')
+  })
+})
+
+describe('releaseNotesToHtml', () => {
+  it('typesets a GitHub-style markdown release body', () => {
+    const html = releaseNotesToHtml(
+      'Release v2.8.2\n\n## What\'s Changed\n\n* Fix Local Certificate Installation and detection bug\n* See https://github.com/bsv-blockchain/bsv-desktop/pull/76\n'
+    )
+
+    expect(html).toContain('<h2>What\'s Changed</h2>')
+    expect(html).toContain('<ul>')
+    expect(html).toContain('<li>Fix Local Certificate Installation and detection bug</li>')
+    expect(html).toContain('href="https://github.com/bsv-blockchain/bsv-desktop/pull/76"')
+    expect(html).toContain('target="_blank"')
+    expect(html).toContain('rel="noopener noreferrer"')
+  })
+
+  it('typesets a GitHub body when the heading sits directly above the list', () => {
+    const html = releaseNotesToHtml(
+      'Release v2.8.2\n\n## What\'s Changed\n* Fix Local Certificate Installation and detection bug\n'
+    )
+
+    expect(html).toContain('<p>Release v2.8.2</p>')
+    expect(html).toContain('<h2>What\'s Changed</h2>')
+    expect(html).toContain('<ul><li>Fix Local Certificate Installation and detection bug</li></ul>')
+  })
+
+  it('keeps existing HTML and forces safe link targets', () => {
+    const html = releaseNotesToHtml(
+      '<p>Read the <a href="https://docs.bsvblockchain.org">docs</a>.</p>'
+    )
+
+    expect(html).toContain('href="https://docs.bsvblockchain.org"')
+    expect(html).toContain('target="_blank"')
+    expect(html).toContain('<p>Read the')
+  })
+
+  it('renders markdown links and bold', () => {
+    const html = releaseNotesToHtml('See [the changelog](https://example.com/notes) for **breaking** changes.')
+
+    expect(html).toContain('<a target="_blank" rel="noopener noreferrer" href="https://example.com/notes">the changelog</a>')
+    expect(html).toContain('<strong>breaking</strong>')
+  })
+})


### PR DESCRIPTION
## Description of Changes

The update available / downloading / ready dialogs were a raw dump: tight padding, release notes rendered as unstyled HTML or markdown, and links left in the browser’s blue/purple.

They now follow the existing navy dialog chrome and read as a short release letter:

- Version stamp in the title bar
- Consistent 24px padding on title, body, and actions (avoids MUI’s title-adjacent `padding-top: 0`)
- Release notes typeset as a document — headings, lists, code, and **navy / sky links** that stay that color when visited
- Markdown from GitHub (including a heading sitting directly above a list, as in v2.8.2) is converted before sanitizing
- Download state uses a large tabular percent instead of a cramped caption

## Linked Issues / Tickets

None

## Testing Procedure

- [x] I have added new unit tests (`test/formatReleaseNotes.test.ts`)
- [x] All tests pass locally (`npm test` — 21 passed)
- [x] Previewed light and dark treatments against the current v2.8.2 notes

## Test plan

- [ ] Settings → **Check for Updates** (dev mode fetches the latest GitHub release)
- [ ] Confirm notes are padded, headings/lists read cleanly, and links are navy (light) or sky (dark) — not browser blue/purple
- [ ] Confirm Later / Download, the download percent, and Install and Restart all still work

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
- [ ] I have run `npm run doc` and `npm run lint` one final time before requesting a review
- [ ] I have fixed all linter errors to ensure these changes are compliant with `ts-standard`
- [ ] I have run `npm version patch` so that my changes will trigger a new version to be released when they are merged