### PR TITLE
OPL-4114: preserve wallet bytes across every Electron bridge route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
-- Preserve BRC-100 byte arrays across the Electron JSON wallet bridge, including current typed arrays and historical numeric-key objects, so payment, send/receive, cryptographic, and transaction-review flows remain compatible across wallet and app versions.
+- Preserve byte arrays across every BRC-100 and app-specific Electron HTTP wallet route, including current typed arrays and historical numeric-key objects, so payment, send/receive, token, cryptographic, and transaction-review flows remain compatible across wallet and app versions.
 
 ## [2.1.0] - 2026-04-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+- Preserve BRC-100 byte arrays across the Electron JSON wallet bridge, including current typed arrays and historical numeric-key objects, so payment, send/receive, cryptographic, and transaction-review flows remain compatible across wallet and app versions.
+
 ## [2.1.0] - 2026-04-08
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "package:win": "electron-builder --win",
     "package:linux": "electron-builder --linux",
     "lint:ci": "echo 'No linting'",
-    "test": "vitest run --config vitest.config.electron.ts test/translations.test.ts test/appIconFallback.test.ts test/formatReleaseNotes.test.ts test/endpoints.test.ts",
+    "test": "vitest run --config vitest.config.electron.ts test/translations.test.ts test/appIconFallback.test.ts test/formatReleaseNotes.test.ts test/endpoints.test.ts test/walletByteJson.test.ts",
     "test:stas": "vitest run --config vitest.config.electron.ts test/stas",
     "test:tokens": "vitest run --config vitest.config.electron.ts test/tokens",
     "test:stas:db": "npm rebuild better-sqlite3 && vitest run --config vitest.config.electron.ts test/stas; npm run rebuild:electron",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "package:win": "electron-builder --win",
     "package:linux": "electron-builder --linux",
     "lint:ci": "echo 'No linting'",
-    "test": "vitest run --config vitest.config.electron.ts test/translations.test.ts test/appIconFallback.test.ts test/formatReleaseNotes.test.ts test/endpoints.test.ts test/walletByteJson.test.ts",
+    "test": "vitest run --config vitest.config.electron.ts test/translations.test.ts test/appIconFallback.test.ts test/formatReleaseNotes.test.ts test/endpoints.test.ts test/onWalletReady.test.ts test/walletByteJson.test.ts",
     "test:stas": "vitest run --config vitest.config.electron.ts test/stas",
     "test:tokens": "vitest run --config vitest.config.electron.ts test/tokens",
     "test:stas:db": "npm rebuild better-sqlite3 && vitest run --config vitest.config.electron.ts test/stas; npm run rebuild:electron",

--- a/src/onWalletReady.ts
+++ b/src/onWalletReady.ts
@@ -36,6 +36,7 @@ import {
   beginHttpBridgeSession,
   endHttpBridgeSession,
 } from './lib/services/httpBridgeSession';
+import { parseWalletPayload, stringifyWalletPayload } from './walletByteJson';
 
 interface HttpRequestEvent {
   method: string;
@@ -361,12 +362,12 @@ export const onWalletReady = async (
         // 1. createAction
         case '/createAction': {
           try {
-            const args = JSON.parse(req.body) as CreateActionArgs;
+            const args = parseWalletPayload(req.body) as CreateActionArgs;
             const result = await wallet.createAction(args, origin);
             response = {
               request_id: req.request_id,
               status: 200,
-              body: JSON.stringify(result),
+              body: stringifyWalletPayload(result),
             };
           } catch (error) {
             if (isWerrReviewActions(error)) {
@@ -375,7 +376,7 @@ export const onWalletReady = async (
               response = {
                 request_id: req.request_id,
                 status: 400,
-                body: JSON.stringify(e)
+                body: stringifyWalletPayload(e)
               };
             } else {
               console.error('createAction error:', error);
@@ -394,12 +395,12 @@ export const onWalletReady = async (
         // 2. signAction
         case '/signAction': {
           try {
-            const args = JSON.parse(req.body) as SignActionArgs;
+            const args = parseWalletPayload(req.body) as SignActionArgs;
             const result = await wallet.signAction(args, origin);
             response = {
               request_id: req.request_id,
               status: 200,
-              body: JSON.stringify(result),
+              body: stringifyWalletPayload(result),
             };
           } catch (error) {
             if (isWerrReviewActions(error)) {
@@ -408,7 +409,7 @@ export const onWalletReady = async (
               response = {
                 request_id: req.request_id,
                 status: 400,
-                body: JSON.stringify(e)
+                body: stringifyWalletPayload(e)
               };
             } else {
               console.error('signAction error:', error);
@@ -427,12 +428,12 @@ export const onWalletReady = async (
         // 3. abortAction
         case '/abortAction': {
           try {
-            const args = JSON.parse(req.body) as AbortActionArgs;
+            const args = parseWalletPayload(req.body) as AbortActionArgs;
             const result = await wallet.abortAction(args, origin);
             response = {
               request_id: req.request_id,
               status: 200,
-              body: JSON.stringify(result),
+              body: stringifyWalletPayload(result),
             };
           } catch (error) {
             console.error('abortAction error:', error);
@@ -450,12 +451,12 @@ export const onWalletReady = async (
         // 4. listActions
         case '/listActions': {
           try {
-            const args = JSON.parse(req.body) as ListActionsArgs;
+            const args = parseWalletPayload(req.body) as ListActionsArgs;
             const result = await wallet.listActions(args, origin);
             response = {
               request_id: req.request_id,
               status: 200,
-              body: JSON.stringify(result),
+              body: stringifyWalletPayload(result),
             };
           } catch (error) {
             console.error('listActions error:', error);
@@ -473,12 +474,12 @@ export const onWalletReady = async (
         // 5. internalizeAction
         case '/internalizeAction': {
           try {
-            const args = JSON.parse(req.body) as InternalizeActionArgs;
+            const args = parseWalletPayload(req.body) as InternalizeActionArgs;
             const result = await wallet.internalizeAction(args, origin);
             response = {
               request_id: req.request_id,
               status: 200,
-              body: JSON.stringify(result),
+              body: stringifyWalletPayload(result),
             };
           } catch (error) {
             if (isWerrReviewActions(error)) {
@@ -487,7 +488,7 @@ export const onWalletReady = async (
               response = {
                 request_id: req.request_id,
                 status: 400,
-                body: JSON.stringify(e)
+                body: stringifyWalletPayload(e)
               };
             } else {
               console.error('internalizeAction error:', error);
@@ -506,12 +507,12 @@ export const onWalletReady = async (
         // 6. listOutputs
         case '/listOutputs': {
           try {
-            const args = JSON.parse(req.body) as ListOutputsArgs;
+            const args = parseWalletPayload(req.body) as ListOutputsArgs;
             const result = await wallet.listOutputs(args, origin);
             response = {
               request_id: req.request_id,
               status: 200,
-              body: JSON.stringify(result),
+              body: stringifyWalletPayload(result),
             };
           } catch (error) {
             console.error('listOutputs error:', error);
@@ -529,12 +530,12 @@ export const onWalletReady = async (
         // 7. relinquishOutput
         case '/relinquishOutput': {
           try {
-            const args = JSON.parse(req.body) as RelinquishOutputArgs;
+            const args = parseWalletPayload(req.body) as RelinquishOutputArgs;
             const result = await wallet.relinquishOutput(args, origin);
             response = {
               request_id: req.request_id,
               status: 200,
-              body: JSON.stringify(result),
+              body: stringifyWalletPayload(result),
             };
           } catch (error) {
             console.error('relinquishOutput error:', error);
@@ -552,12 +553,12 @@ export const onWalletReady = async (
         // 8. getPublicKey
         case '/getPublicKey': {
           try {
-            const args = JSON.parse(req.body) as GetPublicKeyArgs;
+            const args = parseWalletPayload(req.body) as GetPublicKeyArgs;
             const result = await wallet.getPublicKey(args, origin);
             response = {
               request_id: req.request_id,
               status: 200,
-              body: JSON.stringify(result),
+              body: stringifyWalletPayload(result),
             };
           } catch (error) {
             console.error('getPublicKey error:', error);
@@ -575,12 +576,12 @@ export const onWalletReady = async (
         // 9. revealCounterpartyKeyLinkage
         case '/revealCounterpartyKeyLinkage': {
           try {
-            const args = JSON.parse(req.body) as RevealCounterpartyKeyLinkageArgs;
+            const args = parseWalletPayload(req.body) as RevealCounterpartyKeyLinkageArgs;
             const result = await wallet.revealCounterpartyKeyLinkage(args, origin);
             response = {
               request_id: req.request_id,
               status: 200,
-              body: JSON.stringify(result),
+              body: stringifyWalletPayload(result),
             };
           } catch (error) {
             console.error('revealCounterpartyKeyLinkage error:', error);
@@ -598,12 +599,12 @@ export const onWalletReady = async (
         // 10. revealSpecificKeyLinkage
         case '/revealSpecificKeyLinkage': {
           try {
-            const args = JSON.parse(req.body) as RevealSpecificKeyLinkageArgs;
+            const args = parseWalletPayload(req.body) as RevealSpecificKeyLinkageArgs;
             const result = await wallet.revealSpecificKeyLinkage(args, origin);
             response = {
               request_id: req.request_id,
               status: 200,
-              body: JSON.stringify(result),
+              body: stringifyWalletPayload(result),
             };
           } catch (error) {
             console.error('revealSpecificKeyLinkage error:', error);
@@ -621,12 +622,12 @@ export const onWalletReady = async (
         // 11. encrypt
         case '/encrypt': {
           try {
-            const args = JSON.parse(req.body) as WalletEncryptArgs;
+            const args = parseWalletPayload(req.body) as WalletEncryptArgs;
             const result = await wallet.encrypt(args, origin);
             response = {
               request_id: req.request_id,
               status: 200,
-              body: JSON.stringify(result),
+              body: stringifyWalletPayload(result),
             };
           } catch (error) {
             console.error('encrypt error:', error);
@@ -644,12 +645,12 @@ export const onWalletReady = async (
         // 12. decrypt
         case '/decrypt': {
           try {
-            const args = JSON.parse(req.body) as WalletDecryptArgs;
+            const args = parseWalletPayload(req.body) as WalletDecryptArgs;
             const result = await wallet.decrypt(args, origin);
             response = {
               request_id: req.request_id,
               status: 200,
-              body: JSON.stringify(result),
+              body: stringifyWalletPayload(result),
             };
           } catch (error) {
             console.error('decrypt error:', error);
@@ -667,12 +668,12 @@ export const onWalletReady = async (
         // 13. createHmac
         case '/createHmac': {
           try {
-            const args = JSON.parse(req.body) as CreateHmacArgs;
+            const args = parseWalletPayload(req.body) as CreateHmacArgs;
             const result = await wallet.createHmac(args, origin);
             response = {
               request_id: req.request_id,
               status: 200,
-              body: JSON.stringify(result),
+              body: stringifyWalletPayload(result),
             };
           } catch (error) {
             console.error('createHmac error:', error);
@@ -690,12 +691,12 @@ export const onWalletReady = async (
         // 14. verifyHmac
         case '/verifyHmac': {
           try {
-            const args = JSON.parse(req.body) as VerifyHmacArgs;
+            const args = parseWalletPayload(req.body) as VerifyHmacArgs;
             const result = await wallet.verifyHmac(args, origin);
             response = {
               request_id: req.request_id,
               status: 200,
-              body: JSON.stringify(result),
+              body: stringifyWalletPayload(result),
             };
           } catch (error) {
             console.error('verifyHmac error:', error);
@@ -713,12 +714,12 @@ export const onWalletReady = async (
         // 15. createSignature
         case '/createSignature': {
           try {
-            const args = JSON.parse(req.body) as CreateSignatureArgs;
+            const args = parseWalletPayload(req.body) as CreateSignatureArgs;
             const result = await wallet.createSignature(args, origin);
             response = {
               request_id: req.request_id,
               status: 200,
-              body: JSON.stringify(result),
+              body: stringifyWalletPayload(result),
             };
           } catch (error) {
             console.error('createSignature error:', error);
@@ -736,12 +737,12 @@ export const onWalletReady = async (
         // 16. verifySignature
         case '/verifySignature': {
           try {
-            const args = JSON.parse(req.body) as VerifySignatureArgs;
+            const args = parseWalletPayload(req.body) as VerifySignatureArgs;
             const result = await wallet.verifySignature(args, origin);
             response = {
               request_id: req.request_id,
               status: 200,
-              body: JSON.stringify(result),
+              body: stringifyWalletPayload(result),
             };
           } catch (error) {
             console.error('verifySignature error:', error);
@@ -759,12 +760,12 @@ export const onWalletReady = async (
         // 17. acquireCertificate
         case '/acquireCertificate': {
           try {
-            const args = JSON.parse(req.body) as AcquireCertificateArgs;
+            const args = parseWalletPayload(req.body) as AcquireCertificateArgs;
             const result = await wallet.acquireCertificate(args, origin);
             response = {
               request_id: req.request_id,
               status: 200,
-              body: JSON.stringify(result),
+              body: stringifyWalletPayload(result),
             };
           } catch (error) {
             console.error('acquireCertificate error:', error);
@@ -782,12 +783,12 @@ export const onWalletReady = async (
         // 18. listCertificates
         case '/listCertificates': {
           try {
-            const args = JSON.parse(req.body) as ListCertificatesArgs;
+            const args = parseWalletPayload(req.body) as ListCertificatesArgs;
             const result = await wallet.listCertificates(args, origin);
             response = {
               request_id: req.request_id,
               status: 200,
-              body: JSON.stringify(result),
+              body: stringifyWalletPayload(result),
             };
           } catch (error) {
             console.error('listCertificates error:', error);
@@ -805,12 +806,12 @@ export const onWalletReady = async (
         // 19. proveCertificate
         case '/proveCertificate': {
           try {
-            const args = JSON.parse(req.body) as ProveCertificateArgs;
+            const args = parseWalletPayload(req.body) as ProveCertificateArgs;
             const result = await wallet.proveCertificate(args, origin);
             response = {
               request_id: req.request_id,
               status: 200,
-              body: JSON.stringify(result),
+              body: stringifyWalletPayload(result),
             };
           } catch (error) {
             console.error('proveCertificate error:', error);
@@ -828,12 +829,12 @@ export const onWalletReady = async (
         // 20. relinquishCertificate
         case '/relinquishCertificate': {
           try {
-            const args = JSON.parse(req.body) as RelinquishCertificateArgs;
+            const args = parseWalletPayload(req.body) as RelinquishCertificateArgs;
             const result = await wallet.relinquishCertificate(args, origin);
             response = {
               request_id: req.request_id,
               status: 200,
-              body: JSON.stringify(result),
+              body: stringifyWalletPayload(result),
             };
           } catch (error) {
             console.error('relinquishCertificate error:', error);
@@ -851,12 +852,12 @@ export const onWalletReady = async (
         // 21. discoverByIdentityKey
         case '/discoverByIdentityKey': {
           try {
-            const args = JSON.parse(req.body) as DiscoverByIdentityKeyArgs;
+            const args = parseWalletPayload(req.body) as DiscoverByIdentityKeyArgs;
             const result = await wallet.discoverByIdentityKey(args, origin);
             response = {
               request_id: req.request_id,
               status: 200,
-              body: JSON.stringify(result),
+              body: stringifyWalletPayload(result),
             };
           } catch (error) {
             console.error('discoverByIdentityKey error:', error);
@@ -874,12 +875,12 @@ export const onWalletReady = async (
         // 22. discoverByAttributes
         case '/discoverByAttributes': {
           try {
-            const args = JSON.parse(req.body) as DiscoverByAttributesArgs;
+            const args = parseWalletPayload(req.body) as DiscoverByAttributesArgs;
             const result = await wallet.discoverByAttributes(args, origin);
             response = {
               request_id: req.request_id,
               status: 200,
-              body: JSON.stringify(result),
+              body: stringifyWalletPayload(result),
             };
           } catch (error) {
             console.error('discoverByAttributes error:', error);
@@ -901,7 +902,7 @@ export const onWalletReady = async (
             response = {
               request_id: req.request_id,
               status: 200,
-              body: JSON.stringify(result),
+              body: stringifyWalletPayload(result),
             };
           } catch (error) {
             console.error('isAuthenticated error:', error);
@@ -923,7 +924,7 @@ export const onWalletReady = async (
             response = {
               request_id: req.request_id,
               status: 200,
-              body: JSON.stringify(result),
+              body: stringifyWalletPayload(result),
             };
           } catch (error) {
             console.error('waitForAuthentication error:', error);
@@ -945,7 +946,7 @@ export const onWalletReady = async (
             response = {
               request_id: req.request_id,
               status: 200,
-              body: JSON.stringify(result),
+              body: stringifyWalletPayload(result),
             };
           } catch (error) {
             console.error('getHeight error:', error);
@@ -963,12 +964,12 @@ export const onWalletReady = async (
         // 26. getHeaderForHeight
         case '/getHeaderForHeight': {
           try {
-            const args = JSON.parse(req.body) as GetHeaderArgs;
+            const args = parseWalletPayload(req.body) as GetHeaderArgs;
             const result = await wallet.getHeaderForHeight(args, origin);
             response = {
               request_id: req.request_id,
               status: 200,
-              body: JSON.stringify(result),
+              body: stringifyWalletPayload(result),
             };
           } catch (error) {
             console.error('getHeaderForHeight error:', error);
@@ -990,7 +991,7 @@ export const onWalletReady = async (
             response = {
               request_id: req.request_id,
               status: 200,
-              body: JSON.stringify(result),
+              body: stringifyWalletPayload(result),
             };
           } catch (error) {
             console.error('getNetwork error:', error);
@@ -1012,7 +1013,7 @@ export const onWalletReady = async (
             response = {
               request_id: req.request_id,
               status: 200,
-              body: JSON.stringify(result),
+              body: stringifyWalletPayload(result),
             };
           } catch (error) {
             console.error('getVersion error:', error);

--- a/src/walletByteJson.ts
+++ b/src/walletByteJson.ts
@@ -1,0 +1,142 @@
+const byteFieldNames = new Set([
+  "BEEF",
+  "atomicBEEF",
+  "beef",
+  "ciphertext",
+  "competingBeef",
+  "data",
+  "encryptedLinkage",
+  "encryptedLinkageProof",
+  "hashToDirectlySign",
+  "hashToDirectlyVerify",
+  "hmac",
+  "inputBEEF",
+  "payload",
+  "plaintext",
+  "signature",
+  "transaction",
+  "tx",
+]);
+
+const ambiguousContainerFieldNames = new Set(["data", "payload"]);
+const hasOwn = Object.prototype.hasOwnProperty;
+
+function isByte(value: unknown): value is number {
+  return (
+    Number.isInteger(value) &&
+    (value as number) >= 0 &&
+    (value as number) <= 255
+  );
+}
+
+function isUint8Array(value: unknown): value is Uint8Array {
+  return (
+    value != null &&
+    typeof value === "object" &&
+    typeof ArrayBuffer !== "undefined" &&
+    ArrayBuffer.isView(value) &&
+    Object.prototype.toString.call(value) === "[object Uint8Array]"
+  );
+}
+
+function isUnsupportedBinaryView(value: unknown): boolean {
+  return (
+    value != null &&
+    typeof value === "object" &&
+    typeof ArrayBuffer !== "undefined" &&
+    (ArrayBuffer.isView(value) ||
+      Object.prototype.toString.call(value) === "[object ArrayBuffer]")
+  );
+}
+
+function normalizeByteArray(value: unknown): number[] | Uint8Array | undefined {
+  if (isUint8Array(value)) return value;
+  if (isUnsupportedBinaryView(value)) return undefined;
+  if (Array.isArray(value)) {
+    for (let index = 0; index < value.length; index += 1) {
+      if (!hasOwn.call(value, index) || !isByte(value[index])) return undefined;
+    }
+    return value;
+  }
+  if (value == null || typeof value !== "object") return undefined;
+  try {
+    const keys = Object.keys(value);
+    const bytes = new Array<number>(keys.length);
+    for (let index = 0; index < keys.length; index += 1) {
+      if (keys[index] !== String(index)) return undefined;
+      const byte = (value as Record<string, unknown>)[keys[index]];
+      if (!isByte(byte)) return undefined;
+      bytes[index] = byte;
+    }
+    return bytes;
+  } catch {
+    return undefined;
+  }
+}
+
+function isAmbiguousEmptyContainer(key: string, value: unknown): boolean {
+  return (
+    ambiguousContainerFieldNames.has(key) &&
+    value != null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    !isUint8Array(value) &&
+    Object.keys(value).length === 0
+  );
+}
+
+export function normalizeWalletByteFields<T>(value: T): T {
+  const seen = new WeakSet<object>();
+  const visit = (candidate: unknown): void => {
+    if (
+      candidate == null ||
+      typeof candidate !== "object" ||
+      isUint8Array(candidate)
+    )
+      return;
+    if (seen.has(candidate)) return;
+    seen.add(candidate);
+    if (Array.isArray(candidate)) {
+      candidate.forEach(visit);
+      return;
+    }
+    for (const [key, child] of Object.entries(candidate)) {
+      if (byteFieldNames.has(key)) {
+        const bytes = isAmbiguousEmptyContainer(key, child)
+          ? undefined
+          : normalizeByteArray(child);
+        if (bytes != null) (candidate as Record<string, unknown>)[key] = bytes;
+        else visit(child);
+      } else {
+        visit(child);
+      }
+    }
+  };
+  visit(value);
+  return value;
+}
+
+export function stringifyWalletPayload(value: unknown): string {
+  const serialized = JSON.stringify(value, function (key, child) {
+    const original = (this as Record<string, unknown>)[key];
+    if (byteFieldNames.has(key)) {
+      const candidate = original ?? child;
+      const bytes = isAmbiguousEmptyContainer(key, candidate)
+        ? undefined
+        : normalizeByteArray(candidate);
+      if (bytes != null) return Array.from(bytes);
+    }
+    return isUint8Array(original)
+      ? Array.from(original)
+      : isUint8Array(child)
+        ? Array.from(child)
+        : child;
+  });
+  if (serialized === undefined)
+    throw new TypeError("Wallet payload is not JSON serializable");
+  return serialized;
+}
+
+export function parseWalletPayload<T>(value: string): T {
+  return normalizeWalletByteFields(JSON.parse(value)) as T;
+}

--- a/test/onWalletReady.test.ts
+++ b/test/onWalletReady.test.ts
@@ -279,6 +279,41 @@ describe('onWalletReady', () => {
     )
   })
 
+  it('repairs historical request bytes and emits portable response bytes', async () => {
+    const wallet = makeMockWallet({
+      createAction: vi.fn().mockResolvedValue({
+        txid: '22'.repeat(32),
+        tx: new Uint8Array([4, 5, 6]),
+      }),
+    })
+
+    await onWalletReady(wallet)
+    const handler = mockOnHttpRequest.mock.calls[0][0]
+
+    await handler({
+      request_id: 11,
+      path: '/createAction',
+      headers: { origin: 'https://example.com' },
+      body: JSON.stringify({
+        inputBEEF: { 0: 1, 1: 2, 2: 3 },
+        description: 'compatibility test',
+        outputs: [],
+      }),
+      method: 'POST',
+    })
+
+    expect(wallet.createAction).toHaveBeenCalledWith(
+      expect.objectContaining({ inputBEEF: [1, 2, 3] }),
+      'example.com',
+    )
+    const response = mockSendHttpResponse.mock.calls[0][0]
+    expect(response.status).toBe(200)
+    expect(JSON.parse(response.body)).toEqual({
+      txid: '22'.repeat(32),
+      tx: [4, 5, 6],
+    })
+  })
+
   it('preserves WERR_REVIEW_ACTIONS fields when the class name is minified', async () => {
     const reviewActionResults = [{ txid: '00'.repeat(32), status: 'serviceError' }]
     const sendWithResults = [{ txid: '00'.repeat(32), status: 'failed' }]

--- a/test/walletByteJson.test.ts
+++ b/test/walletByteJson.test.ts
@@ -1,0 +1,103 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  normalizeWalletByteFields,
+  parseWalletPayload,
+  stringifyWalletPayload,
+} from "../src/walletByteJson";
+
+const mangled = (bytes: number[]) =>
+  JSON.parse(JSON.stringify(new Uint8Array(bytes)));
+
+describe("wallet byte JSON compatibility", () => {
+  it("keeps every Electron wallet request and result on the compatibility boundary", () => {
+    const source = readFileSync(
+      new URL("../src/onWalletReady.ts", import.meta.url),
+      "utf8",
+    );
+
+    expect(source.match(/parseWalletPayload\(/g)).toHaveLength(23);
+    expect(source.match(/stringifyWalletPayload\(result\)/g)).toHaveLength(28);
+    expect(source.match(/stringifyWalletPayload\(e\)/g)).toHaveLength(3);
+    expect(source).not.toContain("JSON.parse(req.body)");
+    expect(source).not.toContain("JSON.stringify(result)");
+  });
+
+  it("keeps valid number arrays on the identity fast path", () => {
+    const tx = [1, 2, 3];
+    const payload = { tx };
+
+    expect(normalizeWalletByteFields(payload)).toBe(payload);
+    expect(payload.tx).toBe(tx);
+  });
+
+  it("serializes nested typed arrays and subclasses as portable arrays", () => {
+    class ForeignBytes extends Uint8Array {}
+    const json = stringifyWalletPayload({
+      signableTransaction: { tx: new ForeignBytes([1, 2, 3]) },
+      encrypted: new Uint8Array([4, 5]),
+    });
+
+    expect(JSON.parse(json)).toEqual({
+      signableTransaction: { tx: [1, 2, 3] },
+      encrypted: [4, 5],
+    });
+  });
+
+  it("repairs historical numeric-key requests and results recursively", () => {
+    const parsed = parseWalletPayload<{
+      inputBEEF: number[];
+      nested: { transaction: number[] };
+    }>(
+      JSON.stringify({
+        inputBEEF: mangled([1, 2]),
+        nested: { transaction: mangled([3, 4]) },
+      }),
+    );
+
+    expect(parsed).toEqual({
+      inputBEEF: [1, 2],
+      nested: { transaction: [3, 4] },
+    });
+    expect(JSON.parse(stringifyWalletPayload({ tx: mangled([5, 6]) }))).toEqual(
+      {
+        tx: [5, 6],
+      },
+    );
+  });
+
+  it("preserves unrelated numeric records and ambiguous empty containers", () => {
+    const unrelated = mangled([9, 8]);
+    const payload = {
+      unrelated,
+      data: {},
+      payload: { transaction: mangled([1, 2, 3]) },
+    };
+
+    expect(normalizeWalletByteFields(payload)).toEqual({
+      unrelated,
+      data: {},
+      payload: { transaction: [1, 2, 3] },
+    });
+  });
+
+  it("leaves malformed byte records intact so validation fails instead of truncating", () => {
+    const malformed = { 0: 1, 2: 3 };
+    const outOfRange = { 0: 256 };
+    const payload = { tx: malformed, signature: outOfRange };
+
+    normalizeWalletByteFields(payload);
+    expect(payload.tx).toBe(malformed);
+    expect(payload.signature).toBe(outOfRange);
+  });
+
+  it("does not mistake other binary views for empty byte arrays", () => {
+    const view = new DataView(new ArrayBuffer(4));
+    const buffer = new ArrayBuffer(4);
+    const payload = { tx: view, signature: buffer };
+
+    normalizeWalletByteFields(payload);
+    expect(payload.tx).toBe(view);
+    expect(payload.signature).toBe(buffer);
+  });
+});

--- a/test/walletByteJson.test.ts
+++ b/test/walletByteJson.test.ts
@@ -10,17 +10,71 @@ const mangled = (bytes: number[]) =>
   JSON.parse(JSON.stringify(new Uint8Array(bytes)));
 
 describe("wallet byte JSON compatibility", () => {
-  it("keeps every Electron wallet request and result on the compatibility boundary", () => {
+  it("keeps every standard BRC-100 wallet request and result on the compatibility boundary", () => {
     const source = readFileSync(
       new URL("../src/onWalletReady.ts", import.meta.url),
       "utf8",
     );
 
-    expect(source.match(/parseWalletPayload\(/g)).toHaveLength(23);
-    expect(source.match(/stringifyWalletPayload\(result\)/g)).toHaveLength(28);
+    const routesWithArguments = [
+      "createAction",
+      "signAction",
+      "abortAction",
+      "listActions",
+      "internalizeAction",
+      "listOutputs",
+      "relinquishOutput",
+      "getPublicKey",
+      "revealCounterpartyKeyLinkage",
+      "revealSpecificKeyLinkage",
+      "encrypt",
+      "decrypt",
+      "createHmac",
+      "verifyHmac",
+      "createSignature",
+      "verifySignature",
+      "acquireCertificate",
+      "listCertificates",
+      "proveCertificate",
+      "relinquishCertificate",
+      "discoverByIdentityKey",
+      "discoverByAttributes",
+      "getHeaderForHeight",
+    ];
+    const routesWithoutArguments = [
+      "isAuthenticated",
+      "waitForAuthentication",
+      "getHeight",
+      "getNetwork",
+      "getVersion",
+    ];
+
+    const routeBlock = (route: string): string => {
+      const marker = `case '/${route}': {`;
+      const start = source.indexOf(marker);
+      expect(start, `missing /${route} route`).toBeGreaterThanOrEqual(0);
+      const nextCase = source.indexOf("\n        case '", start + marker.length);
+      const nextDefault = source.indexOf("\n        default:", start + marker.length);
+      const candidates = [nextCase, nextDefault].filter((index) => index >= 0);
+      const end = candidates.length > 0 ? Math.min(...candidates) : source.length;
+      return source.slice(start, end);
+    };
+
+    for (const route of routesWithArguments) {
+      const block = routeBlock(route);
+      expect(block, `/${route} request`).toContain("parseWalletPayload(req.body)");
+      expect(block, `/${route} result`).toContain("stringifyWalletPayload(result)");
+      expect(block, `/${route} request`).not.toContain("JSON.parse(req.body)");
+      expect(block, `/${route} result`).not.toContain("JSON.stringify(result)");
+    }
+
+    for (const route of routesWithoutArguments) {
+      const block = routeBlock(route);
+      expect(block, `/${route} result`).toContain("stringifyWalletPayload(result)");
+      expect(block, `/${route} result`).not.toContain("JSON.stringify(result)");
+    }
+
     expect(source.match(/stringifyWalletPayload\(e\)/g)).toHaveLength(3);
-    expect(source).not.toContain("JSON.parse(req.body)");
-    expect(source).not.toContain("JSON.stringify(result)");
   });
 
   it("keeps valid number arrays on the identity fast path", () => {


### PR DESCRIPTION
## Summary

Refreshes and supersedes the conflicting implementation in #79 without rewriting the original upstream branch.

- preserves typed byte fields across all 28 standard BRC-100 Electron bridge routes
- normalizes historical numeric-key byte objects only on known byte-bearing fields
- serializes typed arrays as portable number arrays
- preserves structured WERR_REVIEW_ACTIONS responses
- rebased onto current v2.8.4 master
- scopes compatibility enforcement route-by-route so unrelated custom token JSON routes remain independent

## Verification

- `npm test`: 46/46 passed
- `npm run build`: passed
- `git diff --check`: passed

This is one prerequisite for the OPL-4114 packaged BSV Desktop certificate interoperability matrix. It does not claim that packaged/manual or funded-chain acceptance gates have run.

Supersedes #79.