### PR TITLE
fix(trust): imported certifier icon never renders (icon vs iconUrl)

### DIFF
--- a/src/lib/pages/Dashboard/Trust/AddEntityModal.tsx
+++ b/src/lib/pages/Dashboard/Trust/AddEntityModal.tsx
@@ -113,7 +113,7 @@ const AddEntityModal = ({
       setFieldsValid(false)
       setOpen(false)
       return [
-        { name, icon, description, identityKey, trust: 5 } as Certifier,
+        { name, iconUrl: icon, description, identityKey, trust: 5 } as Certifier,
         ...t
       ]
     })

--- a/src/lib/pages/Dashboard/Trust/AddEntityModal.tsx
+++ b/src/lib/pages/Dashboard/Trust/AddEntityModal.tsx
@@ -112,10 +112,15 @@ const AddEntityModal = ({
       setIdentityKey('')
       setFieldsValid(false)
       setOpen(false)
-      return [
-        { name, iconUrl: icon, description, identityKey, trust: 5 } as Certifier,
-        ...t
-      ]
+      // Typed (not cast) so a field-name drift against Certifier fails to compile.
+      const certifier: Certifier = {
+        name,
+        description,
+        iconUrl: icon,
+        identityKey,
+        trust: 5
+      }
+      return [certifier, ...t]
     })
   }
 

--- a/src/lib/pages/Dashboard/Trust/AddEntityModal.tsx
+++ b/src/lib/pages/Dashboard/Trust/AddEntityModal.tsx
@@ -101,10 +101,10 @@ const AddEntityModal = ({
   }
 
   const handleTrust = async () => {
-    setTrustedEntities(t => {
-      if (t.some(x => x.identityKey === identityKey)) {
+    setTrustedEntities((entities: Certifier[]) => {
+      if (entities.some(x => x.identityKey === identityKey)) {
         toast.error(t('trust_add_entity_duplicate_key'))
-        return t
+        return entities
       }
       setDomain('')
       setName('')
@@ -120,7 +120,7 @@ const AddEntityModal = ({
         identityKey,
         trust: 5
       }
-      return [certifier, ...t]
+      return [certifier, ...entities]
     })
   }
 


### PR DESCRIPTION
## Problem
Adding a certifier from a BRC-68 manifest (Trust > Add Provider) shows the icon correctly in the dialog, but the saved entity renders a broken image in the Trust list: the alt text "<name> icon" shows cropped inside the circle.

`AddEntityModal.tsx` builds the new entity as `{ name, icon, description, identityKey, trust: 5 }`, while `TrustedEntity.tsx` (and the built-in certifiers in `config.ts`, plus the wallet-toolbox `Certifier` type) use `iconUrl`. The `as Certifier` cast hides the mismatch.

<img width="791" height="740" alt="Screenshot 2026-09-02 at 3 59 55 PM" src="https://github.com/user-attachments/assets/642105f2-271f-40ff-aae0-0638d460a416" />


## Fix
Store the manifest icon under `iconUrl`.

## Repro
1. Trust > Add Provider > enter `auth.sigmaidentity.com` > Get Provider Details (icon renders).
2. Add Identity Certifier.
3. The new row in the Trust list shows a broken image.

Reported while running the Sigma Auth certifier interoperability matrix (Open Protocol Labs OPL-4113 / OPL-4114).